### PR TITLE
Fix module line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gltf
+module github.com/qmuntal/gltf
 
 require (
 	github.com/go-playground/locales v0.12.1 // indirect


### PR DESCRIPTION
Thanks for open sourcing this!  I tried using it as a dependency (using modules) but got the following error:
```
go get github.com/qmuntal/gltf
go: finding github.com/qmuntal/gltf v0.7.0
go: github.com/qmuntal/gltf@v0.7.0: parsing go.mod: unexpected module path "gltf"
go: error loading module requirements
```
I'm not an expert on modules, but after looking in to it it looks like the module path is specified incorrectly (the examples at github.com/golang/go/wiki/Modules use the whole path including github).  I also tested the fix by updating the path on my fork (to my fork URL) and it fixed the issue.

In order for go get to see it it will need a new release with a version bump too.