### PR TITLE
decoder: read full external and binary buffer length

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -163,7 +163,7 @@ func (d *Decoder) decodeBuffer(buffer *Buffer) error {
 		r, err = d.cb(buffer.URI)
 		if r != nil && err == nil {
 			buffer.Data = make([]uint8, buffer.ByteLength)
-			_, err = r.Read(buffer.Data)
+			_, err = io.ReadFull(r, buffer.Data)
 			r.Close()
 		}
 	}
@@ -182,7 +182,7 @@ func (d *Decoder) decodeBinaryBuffer(buffer *Buffer) error {
 		return errors.New("gltf: Invalid GLB BIN header")
 	}
 	buffer.Data = make([]uint8, buffer.ByteLength)
-	_, err = d.r.Read(buffer.Data)
+	_, err = io.ReadFull(d.r, buffer.Data)
 	return err
 }
 


### PR DESCRIPTION
https://golang.org/pkg/bufio/#Reader.Read => `The bytes are taken from at most one Read on the underlying Reader, hence n may be less than len(p). To read exactly len(p) bytes, use io.ReadFull(b, p).`

can test it with glTF-Sample-Models/2.0/BoomBox/glTF-Binary/BoomBox.glb, before this commit it most of the buffers end was just zeros on my linux box. `spew.Dump(doc.Buffers)`