### PR TITLE
Improve Read Handler API

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -153,10 +153,13 @@ func (c *chunkedReader) Read(p []byte) (n int, err error) {
 	return 1, nil
 }
 
-func readCallback(payload string) func(string) (io.ReadCloser, error) {
-	return func(name string) (io.ReadCloser, error) {
-		return ioutil.NopCloser(&chunkedReader{s: []byte(payload)}), nil
-	}
+type mockReadHandler struct {
+	Payload string
+}
+
+func (m mockReadHandler) ReadFull(uri string, data []byte) error {
+	copy(data, []byte(m.Payload))
+	return nil
 }
 
 func TestDecoder_decodeBuffer(t *testing.T) {
@@ -174,7 +177,7 @@ func TestDecoder_decodeBuffer(t *testing.T) {
 		{"noURI", &Decoder{}, args{&Buffer{ByteLength: 1, URI: ""}}, nil, true},
 		{"invalidURI", &Decoder{}, args{&Buffer{ByteLength: 1, URI: "../a.bin"}}, nil, true},
 		{"noSchemeErr", NewDecoder(nil), args{&Buffer{ByteLength: 3, URI: "ftp://a.bin"}}, nil, true},
-		{"base", NewDecoder(nil).WithCallback(readCallback("abcdfg")), args{&Buffer{ByteLength: 6, URI: "a.bin"}}, []byte("abcdfg"), false},
+		{"base", NewDecoder(nil).WithReadHandler(&mockReadHandler{"abcdfg"}), args{&Buffer{ByteLength: 6, URI: "a.bin"}}, []byte("abcdfg"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -233,9 +236,9 @@ func TestDecoder_Decode(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"baseJSON", NewDecoder(bytes.NewBufferString("{\"buffers\": [{\"byteLength\": 1, \"URI\": \"a.bin\"}]}")).WithCallback(readCallback("abcdfg")), args{new(Document)}, false},
-		{"onlyGLBHeader", NewDecoder(bytes.NewBuffer([]byte{0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x00, 0x00, 0x5c, 0x06, 0x00, 0x00, 0x4a, 0x53, 0x4f, 0x4e})).WithCallback(readCallback("abcdfg")), args{new(Document)}, true},
-		{"glbNoJSONChunk", NewDecoder(bytes.NewBuffer([]byte{0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x00, 0x00, 0x5c, 0x06, 0x00, 0x00, 0x4a, 0x52, 0x4f, 0x4e})).WithCallback(readCallback("abcdfg")), args{new(Document)}, true},
+		{"baseJSON", NewDecoder(bytes.NewBufferString("{\"buffers\": [{\"byteLength\": 1, \"URI\": \"a.bin\"}]}")).WithReadHandler(&mockReadHandler{"abcdfg"}), args{new(Document)}, false},
+		{"onlyGLBHeader", NewDecoder(bytes.NewBuffer([]byte{0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x00, 0x00, 0x5c, 0x06, 0x00, 0x00, 0x4a, 0x53, 0x4f, 0x4e})).WithReadHandler(&mockReadHandler{"abcdfg"}), args{new(Document)}, true},
+		{"glbNoJSONChunk", NewDecoder(bytes.NewBuffer([]byte{0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x00, 0x00, 0x5c, 0x06, 0x00, 0x00, 0x4a, 0x52, 0x4f, 0x4e})).WithReadHandler(&mockReadHandler{"abcdfg"}), args{new(Document)}, true},
 		{"empty", NewDecoder(bytes.NewBufferString("")), args{new(Document)}, true},
 		{"invalidJSON", NewDecoder(bytes.NewBufferString("{asset: {}}")), args{new(Document)}, true},
 		{"invalidBuffer", NewDecoder(bytes.NewBufferString("{\"buffers\": [{\"byteLength\": 0}]}")), args{new(Document)}, true},

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2,7 +2,6 @@ package gltf
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"io/ioutil"
 	"reflect"
@@ -174,8 +173,7 @@ func TestDecoder_decodeBuffer(t *testing.T) {
 		{"byteLength_0", &Decoder{}, args{&Buffer{ByteLength: 0, URI: "a.bin"}}, nil, true},
 		{"noURI", &Decoder{}, args{&Buffer{ByteLength: 1, URI: ""}}, nil, true},
 		{"invalidURI", &Decoder{}, args{&Buffer{ByteLength: 1, URI: "../a.bin"}}, nil, true},
-		{"cbErr", NewDecoder(nil).WithCallback(func(name string) (io.ReadCloser, error) { return nil, errors.New("") }), args{&Buffer{ByteLength: 3, URI: "a.bin"}}, nil, true},
-		{"noFilBuf", NewDecoder(nil).WithCallback(readCallback("")), args{&Buffer{ByteLength: 30, URI: "a.bin"}}, make([]byte, 30), true},
+		{"noSchemeErr", NewDecoder(nil), args{&Buffer{ByteLength: 3, URI: "ftp://a.bin"}}, nil, true},
 		{"base", NewDecoder(nil).WithCallback(readCallback("abcdfg")), args{&Buffer{ByteLength: 6, URI: "a.bin"}}, []byte("abcdfg"), false},
 	}
 	for _, tt := range tests {

--- a/encode.go
+++ b/encode.go
@@ -22,7 +22,7 @@ func Save(doc *Document, name string) error {
 	return save(doc, name, false)
 }
 
-// Save will save a document as a GLB file with the specified by name.
+// SaveBinary will save a document as a GLB file with the specified by name.
 func SaveBinary(doc *Document, name string) error {
 	return save(doc, name, true)
 }

--- a/io.go
+++ b/io.go
@@ -1,0 +1,48 @@
+package gltf
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+// RelativeFileHandler implements a secure ReadHandler supporting relative paths.
+// If Dir is empty the os.Getws will be used. It comes with directory traversal protection.
+type RelativeFileHandler struct {
+	Dir string
+}
+
+// ReadFull should as io.ReadFull in terms of reading the external resource.
+func (h *RelativeFileHandler) ReadFull(uri string, data []byte) (err error) {
+	dir := h.Dir
+	if dir == "" {
+		if dir, err = os.Getwd(); err != nil {
+			return
+		}
+	}
+	var f http.File
+	f, err = http.Dir(dir).Open(uri)
+	if err != nil {
+		return
+	}
+	_, err = io.ReadFull(f, data)
+	return
+}
+
+// ProtocolRegistry implements a secure ProtocolReadHandler as a map of supported schemes.
+type ProtocolRegistry map[string]ReadHandler
+
+// ReadFull should as io.ReadFull in terms of reading the external resource.
+// An error is returned when the scheme is not supported.
+func (reg ProtocolRegistry) ReadFull(uri string, data []byte) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	if f, ok := reg[u.Scheme]; ok {
+		return f.ReadFull(uri, data)
+	}
+	return errors.New("gltf: not supported scheme")
+}

--- a/io_test.go
+++ b/io_test.go
@@ -1,0 +1,47 @@
+package gltf
+
+import "testing"
+
+func TestRelativeFileHandler_ReadFull(t *testing.T) {
+	type args struct {
+		uri  string
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		h       *RelativeFileHandler
+		args    args
+		wantErr bool
+	}{
+		{"no dir", new(RelativeFileHandler), args{"a.bin", []byte{}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.h.ReadFull(tt.args.uri, tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("RelativeFileHandler.ReadFull() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProtocolRegistry_ReadFull(t *testing.T) {
+	type args struct {
+		uri  string
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		reg     ProtocolRegistry
+		args    args
+		wantErr bool
+	}{
+		{"invalid url", make(ProtocolRegistry), args{"%$·$·23", []byte{}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.reg.ReadFull(tt.args.uri, tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("ProtocolRegistry.ReadFull() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
External resources are read using:
```go
type ReadHandler interface {
	ReadFull(uri string, data []byte) error
}
```

Two implementations provides: ProtocolRegistry and RelativeFileHandler