### PR TITLE
Add undefined magFilter/magFilter values for sampler

### DIFF
--- a/const.go
+++ b/const.go
@@ -260,8 +260,10 @@ func (a *AlphaMode) MarshalJSON() ([]byte, error) {
 type MagFilter uint16
 
 const (
+	// MagUndefined indicates to not specified any magnification filters.
+	MagUndefined MagFilter = iota
 	// MagLinear corresponds to a linear magnification filter.
-	MagLinear MagFilter = iota
+	MagLinear
 	// MagNearest corresponds to a nearest magnification filter.
 	MagNearest
 )
@@ -291,8 +293,10 @@ func (m *MagFilter) MarshalJSON() ([]byte, error) {
 type MinFilter uint16
 
 const (
+	// MinUndefined indicates to not specified any minification filters.
+	MinUndefined MinFilter = iota
 	// MinLinear corresponds to a linear minification filter.
-	MinLinear MinFilter = iota
+	MinLinear
 	// MinNearestMipMapLinear corresponds to a nearest mipmap linear minification filter.
 	MinNearestMipMapLinear
 	// MinNearest corresponds to a nearest minification filter.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -298,7 +298,7 @@ func TestSampler_Decode(t *testing.T) {
 		{"empty", []byte(`{}`), &Sampler{}, false},
 		{"nondefault",
 			[]byte(`{"minFilter":9728,"wrapT":33071}`),
-			&Sampler{MagFilter: MagLinear, MinFilter: MinNearest, WrapS: WrapRepeat, WrapT: WrapClampToEdge},
+			&Sampler{MagFilter: MagUndefined, MinFilter: MinNearest, WrapS: WrapRepeat, WrapT: WrapClampToEdge},
 			false},
 	}
 	for _, tt := range tests {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2,6 +2,7 @@ package gltf
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"reflect"
@@ -281,6 +282,35 @@ func TestDecoder_validateDocumentQuotas(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.d.validateDocumentQuotas(tt.args.doc, tt.args.isBinary); (err != nil) != tt.wantErr {
 				t.Errorf("Decoder.validateDocumentQuotas() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSampler_Decode(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		s       []byte
+		want    *Sampler
+		wantErr bool
+	}{
+		{"empty", []byte(`{}`), &Sampler{}, false},
+		{"nondefault",
+			[]byte(`{"minFilter":9728,"wrapT":33071}`),
+			&Sampler{MagFilter: MagLinear, MinFilter: MinNearest, WrapS: WrapRepeat, WrapT: WrapClampToEdge},
+			false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Sampler
+			err := json.Unmarshal(tt.s, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshaling Sampler error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(&got, tt.want) {
+				t.Errorf("Unmarshaling Sampler = %v, want %v", string(tt.s), tt.want)
 			}
 		})
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -566,6 +566,33 @@ func TestCamera_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestSampler_Encode(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       *Sampler
+		want    []byte
+		wantErr bool
+	}{
+		{"default", &Sampler{MagFilter: 0, MinFilter: 0, WrapS: 0, WrapT: 0}, []byte(`{}`), false},
+		{"empty", &Sampler{}, []byte(`{}`), false},
+		{"nondefault",
+			&Sampler{MagFilter: MagLinear, MinFilter: MinNearest, WrapS: WrapRepeat, WrapT: WrapClampToEdge},
+			[]byte(`{"minFilter":9728,"wrapT":33071}`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Material.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Material.MarshalJSON() = %v, want %v", string(got), string(tt.want))
+			}
+		})
+	}
+}
+
 type fakeExt struct {
 	A int `json:"a"`
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -577,7 +577,7 @@ func TestSampler_Encode(t *testing.T) {
 		{"empty", &Sampler{}, []byte(`{}`), false},
 		{"nondefault",
 			&Sampler{MagFilter: MagLinear, MinFilter: MinNearest, WrapS: WrapRepeat, WrapT: WrapClampToEdge},
-			[]byte(`{"minFilter":9728,"wrapT":33071}`), false},
+			[]byte(`{"magFilter":9729,"minFilter":9728,"wrapT":33071}`), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fixes #36

`MagLinear` and `MinLinear` aren't be included in encoded JSON because they are zero values.
In the `gltf` specification, `magFilter` and `magFilter` doesn't define any default values, so we add zero values to indicate undefiend filters.

(I'm sorry I'm late!)
