### PR TITLE
Auto embed resources without URI when encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ doc.Meshes = []*gltf.Mesh{{
         },
     }},
 }}
+doc.Nodes = []*gltf.Node{{Name: "Pyramid", Mesh: gltf.Index(0)}}
+doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, 0)
+gltf.Save(doc, "./test.gltf")
 ```
 
 ### Data interleaving
@@ -142,6 +145,9 @@ doc.Meshes = []*gltf.Mesh{{
         Attributes: attrs,
     }},
 }}
+doc.Nodes = []*gltf.Node{{Name: "Pyramid", Mesh: gltf.Index(0)}}
+doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, 0)
+gltf.Save(doc, "./test.gltf")
 ```
 
 ### Manipulating bytes

--- a/gltf.go
+++ b/gltf.go
@@ -2,7 +2,6 @@ package gltf
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strings"
 	"sync"
 )
@@ -125,7 +124,7 @@ func (b *Buffer) IsEmbeddedResource() bool {
 
 // EmbeddedResource defines the buffer as an embedded resource and encodes the URI so it points to the the resource.
 func (b *Buffer) EmbeddedResource() {
-	b.URI = fmt.Sprintf("%s,%s", mimetypeApplicationOctet, base64.StdEncoding.EncodeToString(b.Data))
+	b.URI = mimetypeApplicationOctet + "," + base64.StdEncoding.EncodeToString(b.Data)
 }
 
 // marshalData decode the buffer from the URI. If the buffer is not en embedded resource the returned array will be empty.


### PR DESCRIPTION
This PR makes `gltf.Encoder` and `gltf.Save` easier to use when saving non-binary glTF files. The new behavior auto-embed (aka base64-encode) buffers which contain data but have no URI. Previous behavior was to error out.

Closes #53
Updates #45
Updates #49