### PR TITLE
Remove usage of unsafe when checking header size

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -27,8 +27,8 @@
 // }
 //
 // This package favors simplicity and compliance over efficiency,
-// but it is still an order of magnitude more performant than using the built-int `binary` package,
-// as it implements fast paths for basic glTF types and slices.
+// but it is still an order of magnitude more performant than using the built-in
+// `binary` package, as it implements fast paths for basic glTF types and slices.
 package binary
 
 import "encoding/binary"

--- a/decoder.go
+++ b/decoder.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unsafe"
 )
 
 // Open will open a glTF or GLB file specified by name and return the Document.
@@ -101,7 +100,7 @@ func (d *Decoder) decodeDocument(doc *Document) (bool, error) {
 
 func (d *Decoder) readGLBHeader() (*glbHeader, error) {
 	var header glbHeader
-	chunk, err := d.r.Peek(int(unsafe.Sizeof(header)))
+	chunk, err := d.r.Peek(binary.Size(header))
 	if err != nil {
 		return nil, nil
 	}
@@ -115,7 +114,7 @@ func (d *Decoder) readGLBHeader() (*glbHeader, error) {
 }
 
 func (d *Decoder) validateGLBHeader(header *glbHeader) error {
-	if header.JSONHeader.Type != glbChunkJSON || (header.JSONHeader.Length+uint32(unsafe.Sizeof(header))) > header.Length {
+	if header.JSONHeader.Type != glbChunkJSON || (header.JSONHeader.Length+uint32(binary.Size(header))) > header.Length {
 		return errors.New("gltf: Invalid GLB JSON header")
 	}
 	return nil


### PR DESCRIPTION
This PR has the decoder use [binary.Size](https://pkg.go.dev/encoding/binary#Size) in favour of `int(unsafe.Sizeof(header))`, since the `binary` package is either way used for the parsing of the header.

This makes the implementation a bit more robust, since it should handle architectures that might align structures differently. Though in this particular case, due to the simplicity of the struct, it might actually be a bit more of a nit picking.

In addition, it also fixes a small typo (I assumed too small for a separate PR).

The only other place using the `unsafe` package that remains is the `binary/unsafe.go` file. I might be up to writing a separate PR in the future that reworks that to use the more manual approach, as used in `binary/binary.go`, if the owner of this repo is open to the idea of getting rid of `unsafe`.
