### PR TITLE
Ignore EOF when decoding small .gltf files

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -25,7 +25,11 @@ func Open(name string) (*Document, error) {
 	dec := NewDecoderFS(f, os.DirFS(filepath.Dir(name)))
 	doc := new(Document)
 	if err = dec.Decode(doc); err != nil {
-		doc = nil
+		if err == io.EOF {
+			err = nil
+		} else {
+			doc = nil
+		}
 	}
 	return doc, err
 }


### PR DESCRIPTION
When decoding very small files (smaller than one read chunk?), the inner decoder might return io.EOF as error, alongside the document (i.e. the document read might be valid, but it's overwritten with nil in case of io.EOF)