### PR TITLE
Support binary glTF files where first buffer is not binary

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -78,7 +78,7 @@ func (d *Decoder) Decode(doc *Document) error {
 	}
 
 	var externalBufferIndex = 0
-	if isBinary && len(doc.Buffers) > 0 {
+	if isBinary && len(doc.Buffers) > 0 && !doc.Buffers[0].IsEmbeddedResource() {
 		externalBufferIndex = 1
 		if err := d.decodeBinaryBuffer(doc.Buffers[0]); err != nil {
 			return err

--- a/decoder.go
+++ b/decoder.go
@@ -78,7 +78,7 @@ func (d *Decoder) Decode(doc *Document) error {
 	}
 
 	var externalBufferIndex = 0
-	if isBinary && len(doc.Buffers) > 0 && !doc.Buffers[0].IsEmbeddedResource() {
+	if isBinary && len(doc.Buffers) > 0 && doc.Buffers[0].URI == "" {
 		externalBufferIndex = 1
 		if err := d.decodeBinaryBuffer(doc.Buffers[0]); err != nil {
 			return err

--- a/encode.go
+++ b/encode.go
@@ -111,7 +111,7 @@ func (e *Encoder) Encode(doc *Document) error {
 
 	for i := externalBufferIndex; i < len(doc.Buffers); i++ {
 		buf := doc.Buffers[i]
-		if len(buf.Data) == 0 || buf.URI == "" {
+		if len(buf.Data) == 0 || buf.URI == "" || buf.IsEmbeddedResource() {
 			continue
 		}
 		if err = e.encodeBuffer(buf); err != nil {

--- a/gltf_test.go
+++ b/gltf_test.go
@@ -1,6 +1,7 @@
 package gltf
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -323,5 +324,21 @@ func TestSizeOfElement(t *testing.T) {
 				t.Errorf("SizeOfElement() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIssue63(t *testing.T) {
+	srcDoc, err := Open("testdata/issue63/simple.gltf")
+	if nil != err {
+		t.Fatal(err)
+	}
+	outputGlb := filepath.Join(t.TempDir(), "out.glb")
+	err = SaveBinary(srcDoc, outputGlb)
+	if nil != err {
+		t.Fatal(err)
+	}
+	_, err = Open(outputGlb)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/testdata/issue63/simple.gltf
+++ b/testdata/issue63/simple.gltf
@@ -1,0 +1,102 @@
+{
+  "scenes": [
+    {
+      "nodes": [0, 1]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0
+    },
+    {
+      "mesh": 0,
+      "name": "guid",
+      "matrix": [
+        2.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.866,
+        0.5,
+        0.0,
+        0.0,
+        -0.25,
+        0.433,
+        0.0,
+        10.0,
+        20.0,
+        30.0,
+        1.0
+      ]
+    }
+  ],
+
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 1,
+            "NORMAL": 2
+          },
+          "indices": 0
+        }
+      ]
+    }
+  ],
+
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8=",
+      "byteLength": 80
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 6,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 8,
+      "byteLength": 72,
+      "target": 34962
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR",
+      "max": [2],
+      "min": [0]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "max": [1.0, 1.0, 0.0],
+      "min": [0.0, 0.0, 0.0]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 36,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "max": [0.0, 0.0, 1.0],
+      "min": [0.0, 0.0, 1.0]
+    }
+  ],
+
+  "asset": {
+    "version": "2.0"
+  }
+}


### PR DESCRIPTION
The glTF spec allows omitting the binary chunk without precluding the existence of external or embedded buffers.

This PR updates the gltf encoding and decoding process to support this scenario

Fixes #63