### PR TITLE
Avoid out of bounds when calculating b.URI[startPos:]

### DIFF
--- a/gltf.go
+++ b/gltf.go
@@ -2,6 +2,7 @@ package gltf
 
 import (
 	"encoding/base64"
+	"errors"
 	"strings"
 	"sync"
 )
@@ -133,6 +134,9 @@ func (b *Buffer) marshalData() ([]byte, error) {
 		return nil, nil
 	}
 	startPos := len(mimetypeApplicationOctet) + 1
+	if len(b.URI) < startPos {
+		return nil, errors.New("gltf: Invalid base64 content")
+	}
 	sl, err := base64.StdEncoding.DecodeString(b.URI[startPos:])
 	if len(sl) == 0 || err != nil {
 		return nil, err

--- a/gltf_test.go
+++ b/gltf_test.go
@@ -96,6 +96,7 @@ func TestBuffer_marshalData(t *testing.T) {
 		{"empty", &Buffer{URI: "data:application/octet-stream;base64,"}, nil, false},
 		{"test", &Buffer{URI: "data:application/octet-stream;base64,TEST"}, []byte{76, 68, 147}, false},
 		{"complex", &Buffer{URI: "data:application/octet-stream;base64,YW55IGNhcm5hbCBwbGVhcw=="}, []byte{97, 110, 121, 32, 99, 97, 114, 110, 97, 108, 32, 112, 108, 101, 97, 115}, false},
+		{"invalid", &Buffer{URI: "data:application/octet-stream;base64"}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Processing illegal base64 content may cause the program to panic, For example, the following gltf file:

```
{"buffers": [
    {
      "uri": "data:application/octet-stream;base64",
      "byteLength": 1
    }
  ]
}
```

When our program calculates the index, the split character is counted by default, and 1 is automatically added, resulting in an out-of-bounds problem in the program.

```
func (b *Buffer) marshalData() ([]byte, error) {
	if !b.IsEmbeddedResource() {
		return nil, nil
	}
	startPos := len(mimetypeApplicationOctet) + 1//startPos is 37
	//But our b.URI is only 36 in length in this processing.
	sl, err := base64.StdEncoding.DecodeString(b.URI[startPos:])
	if len(sl) == 0 || err != nil {
		return nil, err
	}
	return sl, nil
}
```

## what happened

```
❯ go run main.go
panic: runtime error: slice bounds out of range [37:36]

goroutine 1 [running]:
github.com/qmuntal/gltf.(*Buffer).marshalData(0x1400012c1e0)
        /Users/housihan/go/pkg/mod/github.com/qmuntal/gltf@v0.24.0/gltf.go:136 +0xdc
```