### PR TITLE
Avoid out of bounds when calculating im.URI[startPos:]

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -290,7 +290,6 @@ func TestImage_MarshalData(t *testing.T) {
 		{"complex", &Image{URI: "data:image/png;base64,YW55IGNhcm5hbCBwbGVhcw=="}, []byte{97, 110, 121, 32, 99, 97, 114, 110, 97, 108, 32, 112, 108, 101, 97, 115}, false},
 		{"invalid", &Image{URI: "data:image/png;base64"}, []byte{}, true},
 	}
-		
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.im.MarshalData()

--- a/encode_test.go
+++ b/encode_test.go
@@ -288,8 +288,9 @@ func TestImage_MarshalData(t *testing.T) {
 		{"empty", &Image{URI: "data:image/jpeg;base64,"}, []byte{}, false},
 		{"test", &Image{URI: "data:image/png;base64,TEST"}, []byte{76, 68, 147}, false},
 		{"complex", &Image{URI: "data:image/png;base64,YW55IGNhcm5hbCBwbGVhcw=="}, []byte{97, 110, 121, 32, 99, 97, 114, 110, 97, 108, 32, 112, 108, 101, 97, 115}, false},
-	}
 		{"invalid", &Image{URI: "data:image/png;base64"}, []byte{}, true},
+	}
+		
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.im.MarshalData()

--- a/encode_test.go
+++ b/encode_test.go
@@ -289,6 +289,7 @@ func TestImage_MarshalData(t *testing.T) {
 		{"test", &Image{URI: "data:image/png;base64,TEST"}, []byte{76, 68, 147}, false},
 		{"complex", &Image{URI: "data:image/png;base64,YW55IGNhcm5hbCBwbGVhcw=="}, []byte{97, 110, 121, 32, 99, 97, 114, 110, 97, 108, 32, 112, 108, 101, 97, 115}, false},
 	}
+		{"invalid", &Image{URI: "data:image/png;base64"}, []byte{}, true},
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.im.MarshalData()

--- a/gltf.go
+++ b/gltf.go
@@ -415,6 +415,9 @@ func (im *Image) MarshalData() ([]byte, error) {
 		mimetype = mimetypeImageJPG
 	}
 	startPos := len(mimetype) + 1
+	if len(im.URI) < startPos {
+		return []byte{}, errors.New("gltf: Invalid base64 content")
+	}
 	return base64.StdEncoding.DecodeString(im.URI[startPos:])
 }
 

--- a/gltf_test.go
+++ b/gltf_test.go
@@ -72,7 +72,7 @@ func TestImage_IsEmbeddedResource(t *testing.T) {
 		want bool
 	}{
 		{"png", &Image{URI: "data:image/png;base64,dsjdsaGGUDXGA"}, true},
-		{"jpg", &Image{URI: "data:image/png;base64,dsjdsaGGUDXGA"}, true},
+		{"jpg", &Image{URI: "data:image/jpeg;base64,dsjdsaGGUDXGA"}, true},
 		{"external", &Image{URI: "https://web.com/a"}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Hello, when I was looking at pull 69, I found that there were similar problems when processing images. I fixed it and added test cases. Also edited one of your details. Please take a look~