### PR TITLE
Use float64 for all json numeric properties

### DIFF
--- a/const.go
+++ b/const.go
@@ -9,13 +9,13 @@ import (
 
 var (
 	// DefaultMatrix defines an identity matrix.
-	DefaultMatrix = [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}
+	DefaultMatrix = [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}
 	// DefaultRotation defines a quaternion without rotation.
-	DefaultRotation = [4]float32{0, 0, 0, 1}
+	DefaultRotation = [4]float64{0, 0, 0, 1}
 	// DefaultScale defines a scaling that does not modify the size of the object.
-	DefaultScale = [3]float32{1, 1, 1}
+	DefaultScale = [3]float64{1, 1, 1}
 	// DefaultTranslation defines a translation that does not move the object.
-	DefaultTranslation = [3]float32{0, 0, 0}
+	DefaultTranslation = [3]float64{0, 0, 0}
 )
 
 // Attribute names defined in the spec.
@@ -31,9 +31,9 @@ const (
 )
 
 var (
-	emptyMatrix   = [16]float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	emptyRotation = [4]float32{0, 0, 0, 0}
-	emptyScale    = [3]float32{0, 0, 0}
+	emptyMatrix   = [16]float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	emptyRotation = [4]float64{0, 0, 0, 0}
+	emptyScale    = [3]float64{0, 0, 0}
 )
 
 // The ComponentType is the datatype of components in the attribute. All valid values correspond to WebGL enums.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -30,11 +30,11 @@ func TestOpen(t *testing.T) {
 		{args{"openError", ""}, nil, true},
 		{args{"testdata/Cube/glTF/Cube.gltf", ""}, &Document{
 			Accessors: []*Accessor{
-				{BufferView: Index(0), ByteOffset: 0, ComponentType: ComponentUshort, Count: 36, Max: []float32{35}, Min: []float32{0}, Type: AccessorScalar},
-				{BufferView: Index(1), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float32{1, 1, 1}, Min: []float32{-1, -1, -1}, Type: AccessorVec3},
-				{BufferView: Index(2), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float32{1, 1, 1}, Min: []float32{-1, -1, -1}, Type: AccessorVec3},
-				{BufferView: Index(3), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float32{1, 0, 0, 1}, Min: []float32{0, 0, -1, -1}, Type: AccessorVec4},
-				{BufferView: Index(4), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float32{1, 1}, Min: []float32{-1, -1}, Type: AccessorVec2}},
+				{BufferView: Index(0), ByteOffset: 0, ComponentType: ComponentUshort, Count: 36, Max: []float64{35}, Min: []float64{0}, Type: AccessorScalar},
+				{BufferView: Index(1), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float64{1, 1, 1}, Min: []float64{-1, -1, -1}, Type: AccessorVec3},
+				{BufferView: Index(2), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float64{1, 1, 1}, Min: []float64{-1, -1, -1}, Type: AccessorVec3},
+				{BufferView: Index(3), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float64{1, 0, 0, 1}, Min: []float64{0, 0, -1, -1}, Type: AccessorVec4},
+				{BufferView: Index(4), ByteOffset: 0, ComponentType: ComponentFloat, Count: 36, Max: []float64{1, 1}, Min: []float64{-1, -1}, Type: AccessorVec2}},
 			Asset: Asset{Generator: "VKTS glTF 2.0 exporter", Version: "2.0"},
 			BufferViews: []*BufferView{
 				{Buffer: 0, ByteLength: 72, ByteOffset: 0, Target: TargetElementArrayBuffer},
@@ -45,9 +45,9 @@ func TestOpen(t *testing.T) {
 			},
 			Buffers:   []*Buffer{{ByteLength: 1800, URI: "Cube.bin", Data: readFile("testdata/Cube/glTF/Cube.bin")}},
 			Images:    []*Image{{URI: "Cube_BaseColor.png"}, {URI: "Cube_MetallicRoughness.png"}},
-			Materials: []*Material{{Name: "Cube", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), PBRMetallicRoughness: &PBRMetallicRoughness{BaseColorFactor: &[4]float32{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorTexture: &TextureInfo{Index: 0}, MetallicRoughnessTexture: &TextureInfo{Index: 1}}}},
+			Materials: []*Material{{Name: "Cube", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), PBRMetallicRoughness: &PBRMetallicRoughness{BaseColorFactor: &[4]float64{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorTexture: &TextureInfo{Index: 0}, MetallicRoughnessTexture: &TextureInfo{Index: 1}}}},
 			Meshes:    []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(0), Material: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{NORMAL: 2, POSITION: 1, TANGENT: 3, TEXCOORD_0: 4}}}}},
-			Nodes:     []*Node{{Mesh: Index(0), Name: "Cube", Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}}},
+			Nodes:     []*Node{{Mesh: Index(0), Name: "Cube", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}}},
 			Samplers:  []*Sampler{{WrapS: WrapRepeat, WrapT: WrapRepeat}},
 			Scene:     Index(0),
 			Scenes:    []*Scene{{Nodes: []uint32{0}}},
@@ -57,8 +57,8 @@ func TestOpen(t *testing.T) {
 		}, false},
 		{args{"testdata/Cameras/glTF/Cameras.gltf", "testdata/Cameras/glTF-Embedded/Cameras.gltf"}, &Document{
 			Accessors: []*Accessor{
-				{BufferView: Index(0), ByteOffset: 0, ComponentType: ComponentUshort, Count: 6, Max: []float32{3}, Min: []float32{0}, Type: AccessorScalar},
-				{BufferView: Index(1), ByteOffset: 0, ComponentType: ComponentFloat, Count: 4, Max: []float32{1, 1, 0}, Min: []float32{0, 0, 0}, Type: AccessorVec3},
+				{BufferView: Index(0), ByteOffset: 0, ComponentType: ComponentUshort, Count: 6, Max: []float64{3}, Min: []float64{0}, Type: AccessorScalar},
+				{BufferView: Index(1), ByteOffset: 0, ComponentType: ComponentFloat, Count: 4, Max: []float64{1, 1, 0}, Min: []float64{0, 0, 0}, Type: AccessorVec3},
 			},
 			Asset: Asset{Version: "2.0"},
 			BufferViews: []*BufferView{
@@ -72,9 +72,9 @@ func TestOpen(t *testing.T) {
 			},
 			Meshes: []*Mesh{{Primitives: []*Primitive{{Indices: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{POSITION: 1}}}}},
 			Nodes: []*Node{
-				{Mesh: Index(0), Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{-0.3, 0, 0, 0.9}, Scale: [3]float32{1, 1, 1}},
-				{Camera: Index(0), Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}, Translation: [3]float32{0.5, 0.5, 3.0}},
-				{Camera: Index(1), Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}, Translation: [3]float32{0.5, 0.5, 3.0}},
+				{Mesh: Index(0), Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{-0.3, 0, 0, 0.9}, Scale: [3]float64{1, 1, 1}},
+				{Camera: Index(0), Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}, Translation: [3]float64{0.5, 0.5, 3.0}},
+				{Camera: Index(1), Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}, Translation: [3]float64{0.5, 0.5, 3.0}},
 			},
 			Scene:  nil,
 			Scenes: []*Scene{{Nodes: []uint32{0, 1, 2}}},
@@ -82,7 +82,7 @@ func TestOpen(t *testing.T) {
 		{args{"testdata/BoxVertexColors/glTF-Binary/BoxVertexColors.glb", ""}, &Document{
 			Accessors: []*Accessor{
 				{BufferView: Index(0), ByteOffset: 0, ComponentType: ComponentUshort, Count: 36, Type: AccessorScalar},
-				{BufferView: Index(1), ByteOffset: 0, ComponentType: ComponentFloat, Count: 24, Max: []float32{0.5, 0.5, 0.5}, Min: []float32{-0.5, -0.5, -0.5}, Type: AccessorVec3},
+				{BufferView: Index(1), ByteOffset: 0, ComponentType: ComponentFloat, Count: 24, Max: []float64{0.5, 0.5, 0.5}, Min: []float64{-0.5, -0.5, -0.5}, Type: AccessorVec3},
 				{BufferView: Index(2), ByteOffset: 0, ComponentType: ComponentFloat, Count: 24, Type: AccessorVec3},
 				{BufferView: Index(3), ByteOffset: 0, ComponentType: ComponentFloat, Count: 24, Type: AccessorVec4},
 				{BufferView: Index(4), ByteOffset: 0, ComponentType: ComponentFloat, Count: 24, Type: AccessorVec2},
@@ -96,13 +96,13 @@ func TestOpen(t *testing.T) {
 				{Buffer: 0, ByteLength: 192, ByteOffset: 1032, Target: TargetArrayBuffer},
 			},
 			Buffers:   []*Buffer{{ByteLength: 1224, Data: readFile("testdata/BoxVertexColors/glTF-Binary/BoxVertexColors.glb")[1628+20+8:]}},
-			Materials: []*Material{{Name: "Default", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), PBRMetallicRoughness: &PBRMetallicRoughness{BaseColorFactor: &[4]float32{0.8, 0.8, 0.8, 1}, MetallicFactor: Float(0.1), RoughnessFactor: Float(0.99)}}},
+			Materials: []*Material{{Name: "Default", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), PBRMetallicRoughness: &PBRMetallicRoughness{BaseColorFactor: &[4]float64{0.8, 0.8, 0.8, 1}, MetallicFactor: Float(0.1), RoughnessFactor: Float(0.99)}}},
 			Meshes:    []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(0), Material: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{POSITION: 1, COLOR_0: 3, NORMAL: 2, TEXCOORD_0: 4}}}}},
 			Nodes: []*Node{
-				{Name: "RootNode", Children: []uint32{1, 2, 3}, Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}},
-				{Name: "Mesh", Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}},
-				{Name: "Cube", Mesh: Index(0), Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}},
-				{Name: "Texture Group", Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}},
+				{Name: "RootNode", Children: []uint32{1, 2, 3}, Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
+				{Name: "Mesh", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
+				{Name: "Cube", Mesh: Index(0), Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
+				{Name: "Texture Group", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
 			},
 			Samplers: []*Sampler{{WrapS: WrapRepeat, WrapT: WrapRepeat}},
 			Scene:    Index(0),
@@ -110,7 +110,7 @@ func TestOpen(t *testing.T) {
 		}, false},
 		{args{"testdata/Box With Spaces/glTF/Box With Spaces.gltf", ""}, &Document{
 			Accessors: []*Accessor{
-				{BufferView: Index(0), ComponentType: ComponentFloat, Count: 24, Max: []float32{1, 1, 1}, Min: []float32{-1, -1, -1}, Type: AccessorVec3},
+				{BufferView: Index(0), ComponentType: ComponentFloat, Count: 24, Max: []float64{1, 1, 1}, Min: []float64{-1, -1, -1}, Type: AccessorVec3},
 				{BufferView: Index(1), ComponentType: ComponentFloat, Count: 24, Type: AccessorVec3},
 				{BufferView: Index(2), ComponentType: ComponentFloat, Count: 24, Type: AccessorVec2},
 				{BufferView: Index(3), ComponentType: ComponentUshort, Count: 36, Type: AccessorScalar},
@@ -130,10 +130,10 @@ func TestOpen(t *testing.T) {
 			},
 			Materials: []*Material{{
 				Name: "Material", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), NormalTexture: &NormalTexture{Index: Index(0), Scale: Float(1)}, PBRMetallicRoughness: &PBRMetallicRoughness{
-					BaseColorFactor: &[4]float32{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorTexture: &TextureInfo{Index: 1}, MetallicRoughnessTexture: &TextureInfo{Index: 2},
+					BaseColorFactor: &[4]float64{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorTexture: &TextureInfo{Index: 1}, MetallicRoughnessTexture: &TextureInfo{Index: 2},
 				}}},
 			Meshes:   []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(3), Material: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{NORMAL: 1, POSITION: 0, TEXCOORD_0: 2}}}}},
-			Nodes:    []*Node{{Mesh: Index(0), Name: "Cube", Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}}},
+			Nodes:    []*Node{{Mesh: Index(0), Name: "Cube", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}}},
 			Scene:    Index(0),
 			Scenes:   []*Scene{{Name: "Scene", Nodes: []uint32{0}}},
 			Textures: []*Texture{{Source: Index(0)}, {Source: Index(1)}, {Source: Index(2)}},

--- a/encode.go
+++ b/encode.go
@@ -278,10 +278,10 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 func (n *Node) MarshalJSON() ([]byte, error) {
 	type alias Node
 	tmp := &struct {
-		Matrix      *[16]float32 `json:"matrix,omitempty"`                                          // A 4x4 transformation matrix stored in column-major order.
-		Rotation    *[4]float32  `json:"rotation,omitempty" validate:"omitempty,dive,gte=-1,lte=1"` // The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
-		Scale       *[3]float32  `json:"scale,omitempty"`
-		Translation *[3]float32  `json:"translation,omitempty"`
+		Matrix      *[16]float64 `json:"matrix,omitempty"`                                          // A 4x4 transformation matrix stored in column-major order.
+		Rotation    *[4]float64  `json:"rotation,omitempty" validate:"omitempty,dive,gte=-1,lte=1"` // The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
+		Scale       *[3]float64  `json:"scale,omitempty"`
+		Translation *[3]float64  `json:"translation,omitempty"`
 		*alias
 	}{
 		alias: (*alias)(n),
@@ -339,8 +339,8 @@ func (m *Material) UnmarshalJSON(data []byte) error {
 func (m *Material) MarshalJSON() ([]byte, error) {
 	type alias Material
 	tmp := &struct {
-		EmissiveFactor *[3]float32 `json:"emissiveFactor,omitempty" validate:"dive,gte=0,lte=1"`
-		AlphaCutoff    *float32    `json:"alphaCutoff,omitempty" validate:"omitempty,gte=0"`
+		EmissiveFactor *[3]float64 `json:"emissiveFactor,omitempty" validate:"dive,gte=0,lte=1"`
+		AlphaCutoff    *float64    `json:"alphaCutoff,omitempty" validate:"omitempty,gte=0"`
 		*alias
 	}{
 		alias: (*alias)(m),
@@ -348,7 +348,7 @@ func (m *Material) MarshalJSON() ([]byte, error) {
 	if m.AlphaCutoff != nil && *m.AlphaCutoff != 0.5 {
 		tmp.AlphaCutoff = m.AlphaCutoff
 	}
-	if m.EmissiveFactor != [3]float32{0, 0, 0} {
+	if m.EmissiveFactor != [3]float64{0, 0, 0} {
 		tmp.EmissiveFactor = &m.EmissiveFactor
 	}
 	return json.Marshal(tmp)
@@ -370,7 +370,7 @@ func (n *NormalTexture) MarshalJSON() ([]byte, error) {
 	type alias NormalTexture
 	if n.Scale != nil && *n.Scale == 1 {
 		return json.Marshal(&struct {
-			Scale float32 `json:"scale,omitempty"`
+			Scale float64 `json:"scale,omitempty"`
 			*alias
 		}{
 			Scale: 0,
@@ -396,7 +396,7 @@ func (o *OcclusionTexture) MarshalJSON() ([]byte, error) {
 	type alias OcclusionTexture
 	if o.Strength != nil && *o.Strength == 1 {
 		return json.Marshal(&struct {
-			Strength float32 `json:"strength,omitempty"`
+			Strength float64 `json:"strength,omitempty"`
 			*alias
 		}{
 			Strength: 0,
@@ -409,7 +409,7 @@ func (o *OcclusionTexture) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshal the pbr with the correct default values.
 func (p *PBRMetallicRoughness) UnmarshalJSON(data []byte) error {
 	type alias PBRMetallicRoughness
-	tmp := alias(PBRMetallicRoughness{BaseColorFactor: &[4]float32{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1)})
+	tmp := alias(PBRMetallicRoughness{BaseColorFactor: &[4]float64{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1)})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
 		*p = PBRMetallicRoughness(tmp)
@@ -431,7 +431,7 @@ func (p *PBRMetallicRoughness) MarshalJSON() ([]byte, error) {
 	if p.RoughnessFactor != nil && *p.RoughnessFactor == 1 {
 		tmp.RoughnessFactor = nil
 	}
-	if p.BaseColorFactor != nil && *p.BaseColorFactor == [4]float32{1, 1, 1, 1} {
+	if p.BaseColorFactor != nil && *p.BaseColorFactor == [4]float64{1, 1, 1, 1} {
 		tmp.BaseColorFactor = nil
 	}
 	return json.Marshal(tmp)

--- a/encode_test.go
+++ b/encode_test.go
@@ -159,7 +159,7 @@ func TestEncoder_Encode(t *testing.T) {
 		{"withExtensions", args{&Document{Extras: 8.0, ExtensionsUsed: []string{"c"}, ExtensionsRequired: []string{"d", "e"}}}, false},
 		{"withAsset", args{&Document{Asset: Asset{Extras: 8.0, Copyright: "@2019", Generator: "qmuntal/gltf", Version: "2.0", MinVersion: "1.0"}}}, false},
 		{"withAccessors", args{&Document{Accessors: []*Accessor{
-			{Extras: 8.0, Name: "acc_1", BufferView: Index(0), ByteOffset: 50, ComponentType: ComponentByte, Normalized: true, Count: 5, Type: AccessorVec3, Max: []float32{1, 2}, Min: []float32{2.4}},
+			{Extras: 8.0, Name: "acc_1", BufferView: Index(0), ByteOffset: 50, ComponentType: ComponentByte, Normalized: true, Count: 5, Type: AccessorVec3, Max: []float64{1, 2}, Min: []float64{2.4}},
 			{BufferView: Index(0), Normalized: false, Count: 50, Type: AccessorVec4, Sparse: &Sparse{Extras: 8.0, Count: 2,
 				Values:  SparseValues{Extras: 8.0, BufferView: 1, ByteOffset: 2},
 				Indices: SparseIndices{Extras: 8.0, BufferView: 1, ByteOffset: 2, ComponentType: ComponentFloat}},
@@ -192,10 +192,10 @@ func TestEncoder_Encode(t *testing.T) {
 			{Extras: 8.0, Name: "external", URI: "https://web.com/a", MimeType: "data:image/png"},
 		}}}, false},
 		{"withMaterials", args{&Document{Materials: []*Material{
-			{Extras: 8.0, Name: "base", EmissiveFactor: [3]float32{1.0, 1.0, 1.0}, DoubleSided: true, AlphaCutoff: Float(0.5), AlphaMode: AlphaOpaque},
+			{Extras: 8.0, Name: "base", EmissiveFactor: [3]float64{1.0, 1.0, 1.0}, DoubleSided: true, AlphaCutoff: Float(0.5), AlphaMode: AlphaOpaque},
 			{Extras: 8.0, Name: "pbr", AlphaCutoff: Float(0.5), AlphaMode: AlphaOpaque,
 				PBRMetallicRoughness: &PBRMetallicRoughness{
-					Extras: 8.0, MetallicFactor: Float(1), RoughnessFactor: Float(2), BaseColorFactor: &[4]float32{0.8, 0.8, 0.8, 1},
+					Extras: 8.0, MetallicFactor: Float(1), RoughnessFactor: Float(2), BaseColorFactor: &[4]float64{0.8, 0.8, 0.8, 1},
 					BaseColorTexture:         &TextureInfo{Extras: 8.0, Index: 1, TexCoord: 3},
 					MetallicRoughnessTexture: &TextureInfo{Extras: 8.0, Index: 6, TexCoord: 5},
 				},
@@ -209,7 +209,7 @@ func TestEncoder_Encode(t *testing.T) {
 			{Extras: 8.0, Name: "emmisice", AlphaCutoff: Float(0.5), AlphaMode: AlphaMask, EmissiveTexture: &TextureInfo{Extras: 8.0, Index: 4, TexCoord: 50}},
 		}}}, false},
 		{"withMeshes", args{&Document{Meshes: []*Mesh{
-			{Extras: 8.0, Name: "mesh_1", Weights: []float32{1.2, 2}},
+			{Extras: 8.0, Name: "mesh_1", Weights: []float64{1.2, 2}},
 			{Extras: 8.0, Name: "mesh_2", Primitives: []*Primitive{
 				{Extras: 8.0, Attributes: Attribute{POSITION: 1}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
 				{Extras: 8.0, Targets: []Attribute{{POSITION: 1, "THEN": 4}, {"OTHER": 2}}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
@@ -217,9 +217,9 @@ func TestEncoder_Encode(t *testing.T) {
 		}}}, false},
 		{"withNodes", args{&Document{Nodes: []*Node{
 			{Extras: 8.0, Name: "n-1", Camera: Index(1), Children: []uint32{1, 2}, Skin: Index(3),
-				Matrix: [16]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, Mesh: Index(15), Rotation: [4]float32{1.5, 1.3, 12, 0}, Scale: [3]float32{1, 3, 4}, Translation: [3]float32{0, 7.8, 9}, Weights: []float32{1, 3}},
+				Matrix: [16]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, Mesh: Index(15), Rotation: [4]float64{1.5, 1.3, 12, 0}, Scale: [3]float64{1, 3, 4}, Translation: [3]float64{0, 7.8, 9}, Weights: []float64{1, 3}},
 			{Extras: 8.0, Name: "n-2", Camera: Index(1), Children: []uint32{1, 2}, Skin: Index(3),
-				Matrix: [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Mesh: Index(15), Rotation: [4]float32{0, 0, 0, 1}, Scale: [3]float32{1, 1, 1}},
+				Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Mesh: Index(15), Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
 		}}}, false},
 		{"withSampler", args{&Document{Samplers: []*Sampler{
 			{Extras: 8.0, Name: "s_1", MagFilter: MagLinear, MinFilter: MinLinearMipMapLinear, WrapS: WrapClampToEdge, WrapT: WrapMirroredRepeat},
@@ -316,22 +316,22 @@ func TestNode_UnmarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"default", new(Node), args{[]byte("{}")}, &Node{
-			Matrix:   [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
-			Rotation: [4]float32{0, 0, 0, 1},
-			Scale:    [3]float32{1, 1, 1},
+			Matrix:   [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
+			Rotation: [4]float64{0, 0, 0, 1},
+			Scale:    [3]float64{1, 1, 1},
 		}, false},
 		{"nodefault", new(Node), args{[]byte(`{"matrix":[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],"rotation":[0,0,0,1],"scale":[1,1,1],"camera":0,"mesh":0,"skin":0}`)}, &Node{
-			Matrix:   [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
-			Rotation: [4]float32{0, 0, 0, 1},
-			Scale:    [3]float32{1, 1, 1},
+			Matrix:   [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
+			Rotation: [4]float64{0, 0, 0, 1},
+			Scale:    [3]float64{1, 1, 1},
 			Camera:   Index(0),
 			Mesh:     Index(0),
 			Skin:     Index(0),
 		}, false},
 		{"nodefault", new(Node), args{[]byte(`{"matrix":[1,2,2,0,0,1,3,4,0,0,1,0,5,0,0,5],"rotation":[1,2,3,4],"scale":[2,3,4],"camera":1,"mesh":2,"skin":3}`)}, &Node{
-			Matrix:   [16]float32{1, 2, 2, 0, 0, 1, 3, 4, 0, 0, 1, 0, 5, 0, 0, 5},
-			Rotation: [4]float32{1, 2, 3, 4},
-			Scale:    [3]float32{2, 3, 4},
+			Matrix:   [16]float64{1, 2, 2, 0, 0, 1, 3, 4, 0, 0, 1, 0, 5, 0, 0, 5},
+			Rotation: [4]float64{1, 2, 3, 4},
+			Scale:    [3]float64{2, 3, 4},
 			Camera:   Index(1),
 			Mesh:     Index(2),
 			Skin:     Index(3),
@@ -444,9 +444,9 @@ func TestPBRMetallicRoughness_UnmarshalJSON(t *testing.T) {
 		want    *PBRMetallicRoughness
 		wantErr bool
 	}{
-		{"default", new(PBRMetallicRoughness), args{[]byte("{}")}, &PBRMetallicRoughness{BaseColorFactor: &[4]float32{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1)}, false},
+		{"default", new(PBRMetallicRoughness), args{[]byte("{}")}, &PBRMetallicRoughness{BaseColorFactor: &[4]float64{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1)}, false},
 		{"nodefault", new(PBRMetallicRoughness), args{[]byte(`{"baseColorFactor": [0.1,0.2,0.6,0.7],"metallicFactor":0.5,"roughnessFactor":0.1}`)}, &PBRMetallicRoughness{
-			BaseColorFactor: &[4]float32{0.1, 0.2, 0.6, 0.7}, MetallicFactor: Float(0.5), RoughnessFactor: Float(0.1),
+			BaseColorFactor: &[4]float64{0.1, 0.2, 0.6, 0.7}, MetallicFactor: Float(0.5), RoughnessFactor: Float(0.1),
 		}, false},
 	}
 	for _, tt := range tests {
@@ -470,28 +470,28 @@ func TestNode_MarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"default", &Node{
-			Matrix:   [16]float32{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
-			Rotation: [4]float32{0, 0, 0, 1},
-			Scale:    [3]float32{1, 1, 1},
+			Matrix:   [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
+			Rotation: [4]float64{0, 0, 0, 1},
+			Scale:    [3]float64{1, 1, 1},
 		}, []byte("{}"), false},
 		{"default2", &Node{
-			Matrix:   [16]float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			Rotation: [4]float32{0, 0, 0, 0},
-			Scale:    [3]float32{0, 0, 0},
+			Matrix:   [16]float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Rotation: [4]float64{0, 0, 0, 0},
+			Scale:    [3]float64{0, 0, 0},
 		}, []byte("{}"), false},
 		{"empty", &Node{
-			Matrix:   [16]float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			Rotation: [4]float32{0, 0, 0, 0},
-			Scale:    [3]float32{0, 0, 0},
+			Matrix:   [16]float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Rotation: [4]float64{0, 0, 0, 0},
+			Scale:    [3]float64{0, 0, 0},
 			Camera:   Index(0),
 			Skin:     Index(0),
 			Mesh:     Index(0),
 		}, []byte(`{"camera":0,"skin":0,"mesh":0}`), false},
 		{"nodefault", &Node{
-			Matrix:      [16]float32{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			Rotation:    [4]float32{1, 0, 0, 0},
-			Scale:       [3]float32{1, 0, 0},
-			Translation: [3]float32{1, 0, 0},
+			Matrix:      [16]float64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Rotation:    [4]float64{1, 0, 0, 0},
+			Scale:       [3]float64{1, 0, 0},
+			Translation: [3]float64{1, 0, 0},
 			Camera:      Index(1),
 			Skin:        Index(1),
 			Mesh:        Index(1),
@@ -593,9 +593,9 @@ func TestPBRMetallicRoughness_MarshalJSON(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"default", &PBRMetallicRoughness{MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorFactor: &[4]float32{1, 1, 1, 1}}, []byte(`{}`), false},
+		{"default", &PBRMetallicRoughness{MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorFactor: &[4]float64{1, 1, 1, 1}}, []byte(`{}`), false},
 		{"empty", &PBRMetallicRoughness{MetallicFactor: Float(0), RoughnessFactor: Float(0)}, []byte(`{"metallicFactor":0,"roughnessFactor":0}`), false},
-		{"nodefault", &PBRMetallicRoughness{MetallicFactor: Float(0.5), RoughnessFactor: Float(0.5), BaseColorFactor: &[4]float32{1, 0.5, 1, 1}}, []byte(`{"baseColorFactor":[1,0.5,1,1],"metallicFactor":0.5,"roughnessFactor":0.5}`), false},
+		{"nodefault", &PBRMetallicRoughness{MetallicFactor: Float(0.5), RoughnessFactor: Float(0.5), BaseColorFactor: &[4]float64{1, 0.5, 1, 1}}, []byte(`{"baseColorFactor":[1,0.5,1,1],"metallicFactor":0.5,"roughnessFactor":0.5}`), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func ExampleSave() {
 	doc := &gltf.Document{
 		Accessors: []*gltf.Accessor{
 			{BufferView: gltf.Index(0), ComponentType: gltf.ComponentUshort, Count: 36, Type: gltf.AccessorScalar},
-			{BufferView: gltf.Index(1), ComponentType: gltf.ComponentFloat, Count: 24, Max: []float32{0.5, 0.5, 0.5}, Min: []float32{-0.5, -0.5, -0.5}, Type: gltf.AccessorVec3},
+			{BufferView: gltf.Index(1), ComponentType: gltf.ComponentFloat, Count: 24, Max: []float64{0.5, 0.5, 0.5}, Min: []float64{-0.5, -0.5, -0.5}, Type: gltf.AccessorVec3},
 			{BufferView: gltf.Index(2), ComponentType: gltf.ComponentFloat, Count: 24, Type: gltf.AccessorVec3},
 			{BufferView: gltf.Index(3), ComponentType: gltf.ComponentFloat, Count: 24, Type: gltf.AccessorVec4},
 			{BufferView: gltf.Index(4), ComponentType: gltf.ComponentFloat, Count: 24, Type: gltf.AccessorVec2},
@@ -34,7 +34,7 @@ func ExampleSave() {
 		Buffers: []*gltf.Buffer{{ByteLength: 1224, Data: []byte{97, 110, 121, 32, 99, 97, 114, 110, 97, 108, 32, 112, 108, 101, 97, 115}}},
 		Materials: []*gltf.Material{{
 			Name: "Default", AlphaMode: gltf.AlphaOpaque, AlphaCutoff: gltf.Float(0.5),
-			PBRMetallicRoughness: &gltf.PBRMetallicRoughness{BaseColorFactor: &[4]float32{0.8, 0.8, 0.8, 1}, MetallicFactor: gltf.Float(0.1), RoughnessFactor: gltf.Float(0.99)},
+			PBRMetallicRoughness: &gltf.PBRMetallicRoughness{BaseColorFactor: &[4]float64{0.8, 0.8, 0.8, 1}, MetallicFactor: gltf.Float(0.1), RoughnessFactor: gltf.Float(0.99)},
 		}},
 		Meshes: []*gltf.Mesh{{Name: "Cube", Primitives: []*gltf.Primitive{{Indices: gltf.Index(0), Material: gltf.Index(0), Mode: gltf.PrimitiveTriangles, Attributes: map[string]uint32{gltf.POSITION: 1, gltf.COLOR_0: 3, gltf.NORMAL: 2, gltf.TEXCOORD_0: 4}}}}},
 		Nodes: []*gltf.Node{

--- a/ext/lightspuntual/lightspuntual.go
+++ b/ext/lightspuntual/lightspuntual.go
@@ -50,12 +50,12 @@ type LightIndex uint32
 
 // Spot defines the spot cone.
 type Spot struct {
-	InnerConeAngle float32  `json:"innerConeAngle,omitempty"`
-	OuterConeAngle *float32 `json:"outerConeAngle,omitempty"`
+	InnerConeAngle float64  `json:"innerConeAngle,omitempty"`
+	OuterConeAngle *float64 `json:"outerConeAngle,omitempty"`
 }
 
 // OuterConeAngleOrDefault returns the OuterConeAngle if it is not nil, else return the default one.
-func (s *Spot) OuterConeAngleOrDefault() float32 {
+func (s *Spot) OuterConeAngleOrDefault() float64 {
 	if s.OuterConeAngle == nil {
 		return math.Pi / 4
 	}
@@ -81,14 +81,14 @@ type Lights []*Light
 type Light struct {
 	Type      string      `json:"type"`
 	Name      string      `json:"name,omitempty"`
-	Color     *[3]float32 `json:"color,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
-	Intensity *float32    `json:"intensity,omitempty"`
-	Range     *float32    `json:"range,omitempty"`
+	Color     *[3]float64 `json:"color,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
+	Intensity *float64    `json:"intensity,omitempty"`
+	Range     *float64    `json:"range,omitempty"`
 	Spot      *Spot       `json:"spot,omitempty"`
 }
 
 // IntensityOrDefault returns the itensity if it is not nil, else return the default one.
-func (l *Light) IntensityOrDefault() float32 {
+func (l *Light) IntensityOrDefault() float64 {
 	if l.Intensity == nil {
 		return 1
 	}
@@ -96,9 +96,9 @@ func (l *Light) IntensityOrDefault() float32 {
 }
 
 // ColorOrDefault returns the color if it is not nil, else return the default one.
-func (l *Light) ColorOrDefault() [3]float32 {
+func (l *Light) ColorOrDefault() [3]float64 {
 	if l.Color == nil {
-		return [3]float32{1, 1, 1}
+		return [3]float64{1, 1, 1}
 	}
 	return *l.Color
 }
@@ -106,7 +106,7 @@ func (l *Light) ColorOrDefault() [3]float32 {
 // UnmarshalJSON unmarshal the light with the correct default values.
 func (l *Light) UnmarshalJSON(data []byte) error {
 	type alias Light
-	tmp := alias(Light{Color: &[3]float32{1, 1, 1}, Intensity: gltf.Float(1), Range: gltf.Float(float32(math.Inf(0)))})
+	tmp := alias(Light{Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1), Range: gltf.Float(math.Inf(0))})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
 		*l = Light(tmp)

--- a/ext/lightspuntual/lightspuntual_test.go
+++ b/ext/lightspuntual/lightspuntual_test.go
@@ -13,7 +13,7 @@ func TestLight_IntensityOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		l    *Light
-		want float32
+		want float64
 	}{
 		{"empty", &Light{}, 1},
 		{"other", &Light{Intensity: gltf.Float(0.5)}, 0.5},
@@ -31,10 +31,10 @@ func TestLight_ColorOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		l    *Light
-		want [3]float32
+		want [3]float64
 	}{
-		{"empty", &Light{}, [3]float32{1, 1, 1}},
-		{"other", &Light{Color: &[3]float32{0.8, 0.8, 0.8}}, [3]float32{0.8, 0.8, 0.8}},
+		{"empty", &Light{}, [3]float64{1, 1, 1}},
+		{"other", &Light{Color: &[3]float64{0.8, 0.8, 0.8}}, [3]float64{0.8, 0.8, 0.8}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestSpot_OuterConeAngleOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		s    *Spot
-		want float32
+		want float64
 	}{
 		{"empty", &Spot{}, math.Pi / 4},
 		{"other", &Spot{OuterConeAngle: gltf.Float(0.5)}, 0.5},
@@ -75,7 +75,7 @@ func TestLight_UnmarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"default", new(Light), args{[]byte("{}")}, &Light{
-			Color: &[3]float32{1, 1, 1}, Intensity: gltf.Float(1), Range: gltf.Float(float32(math.Inf(0))),
+			Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1), Range: gltf.Float(math.Inf(0)),
 		}, false},
 		{"nodefault", new(Light), args{[]byte(`{
 			"color": [0.3, 0.7, 1.0],
@@ -88,7 +88,7 @@ func TestLight_UnmarshalJSON(t *testing.T) {
 			  "outerConeAngle": 2.0
 			}
 		  }`)}, &Light{
-			Name: "AAA", Type: "spot", Color: &[3]float32{0.3, 0.7, 1}, Intensity: gltf.Float(40), Range: gltf.Float(10),
+			Name: "AAA", Type: "spot", Color: &[3]float64{0.3, 0.7, 1}, Intensity: gltf.Float(40), Range: gltf.Float(10),
 			Spot: &Spot{
 				InnerConeAngle: 1.0,
 				OuterConeAngle: gltf.Float(2.0),
@@ -133,8 +133,8 @@ func TestUnmarshal(t *testing.T) {
 			  "type": "point"
 			}
 		  ]}`)}, Lights{
-			{Color: &[3]float32{1, 0.9, 0.7}, Name: "Directional", Intensity: gltf.Float(3.0), Type: "directional", Range: gltf.Float(float32(math.Inf(0)))},
-			{Color: &[3]float32{1, 0, 0}, Name: "Point", Intensity: gltf.Float(20.0), Type: "point", Range: gltf.Float(float32(math.Inf(0)))},
+			{Color: &[3]float64{1, 0.9, 0.7}, Name: "Directional", Intensity: gltf.Float(3.0), Type: "directional", Range: gltf.Float(math.Inf(0))},
+			{Color: &[3]float64{1, 0, 0}, Name: "Point", Intensity: gltf.Float(20.0), Type: "point", Range: gltf.Float(math.Inf(0))},
 		}, false},
 	}
 	for _, tt := range tests {

--- a/ext/specular/specular.go
+++ b/ext/specular/specular.go
@@ -25,17 +25,17 @@ func init() {
 
 // PBRSpecularGlossiness defines a specular-glossiness material model.
 type PBRSpecularGlossiness struct {
-	DiffuseFactor             *[4]float32       `json:"diffuseFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
+	DiffuseFactor             *[4]float64       `json:"diffuseFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
 	DiffuseTexture            *gltf.TextureInfo `json:"diffuseTexture,omitempty"`
-	SpecularFactor            *[3]float32       `json:"specularFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
-	GlossinessFactor          *float32          `json:"glossinessFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
+	SpecularFactor            *[3]float64       `json:"specularFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
+	GlossinessFactor          *float64          `json:"glossinessFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
 	SpecularGlossinessTexture *gltf.TextureInfo `json:"specularGlossinessTexture,omitempty"`
 }
 
 // UnmarshalJSON unmarshal the pbr with the correct default values.
 func (p *PBRSpecularGlossiness) UnmarshalJSON(data []byte) error {
 	type alias PBRSpecularGlossiness
-	tmp := alias(PBRSpecularGlossiness{DiffuseFactor: &[4]float32{1, 1, 1, 1}, SpecularFactor: &[3]float32{1, 1, 1}, GlossinessFactor: gltf.Float(1)})
+	tmp := alias(PBRSpecularGlossiness{DiffuseFactor: &[4]float64{1, 1, 1, 1}, SpecularFactor: &[3]float64{1, 1, 1}, GlossinessFactor: gltf.Float(1)})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
 		*p = PBRSpecularGlossiness(tmp)
@@ -51,10 +51,10 @@ func (p *PBRSpecularGlossiness) MarshalJSON() ([]byte, error) {
 		if p.GlossinessFactor != nil && *p.GlossinessFactor == 1 {
 			out = removeProperty([]byte(`"glossinessFactor":1`), out)
 		}
-		if p.DiffuseFactor != nil && *p.DiffuseFactor == [4]float32{1, 1, 1, 1} {
+		if p.DiffuseFactor != nil && *p.DiffuseFactor == [4]float64{1, 1, 1, 1} {
 			out = removeProperty([]byte(`"diffuseFactor":[1,1,1,1]`), out)
 		}
-		if p.SpecularFactor != nil && *p.SpecularFactor == [3]float32{1, 1, 1} {
+		if p.SpecularFactor != nil && *p.SpecularFactor == [3]float64{1, 1, 1} {
 			out = removeProperty([]byte(`"specularFactor":[1,1,1]`), out)
 		}
 		out = sanitizeJSON(out)

--- a/ext/specular/specular_test.go
+++ b/ext/specular/specular_test.go
@@ -18,9 +18,9 @@ func TestPBRSpecularGlossiness_UnmarshalJSON(t *testing.T) {
 		want    *PBRSpecularGlossiness
 		wantErr bool
 	}{
-		{"default", new(PBRSpecularGlossiness), args{[]byte("{}")}, &PBRSpecularGlossiness{DiffuseFactor: &[4]float32{1, 1, 1, 1}, SpecularFactor: &[3]float32{1, 1, 1}, GlossinessFactor: gltf.Float(1)}, false},
+		{"default", new(PBRSpecularGlossiness), args{[]byte("{}")}, &PBRSpecularGlossiness{DiffuseFactor: &[4]float64{1, 1, 1, 1}, SpecularFactor: &[3]float64{1, 1, 1}, GlossinessFactor: gltf.Float(1)}, false},
 		{"nodefault", new(PBRSpecularGlossiness), args{[]byte(`{"diffuseFactor": [0.1,0.2,0.3,0.4],"specularFactor":[0.5,0.6,0.7],"glossinessFactor":0.5}`)}, &PBRSpecularGlossiness{
-			DiffuseFactor: &[4]float32{0.1, 0.2, 0.3, 0.4}, SpecularFactor: &[3]float32{0.5, 0.6, 0.7}, GlossinessFactor: gltf.Float(0.5),
+			DiffuseFactor: &[4]float64{0.1, 0.2, 0.3, 0.4}, SpecularFactor: &[3]float64{0.5, 0.6, 0.7}, GlossinessFactor: gltf.Float(0.5),
 		}, false},
 	}
 	for _, tt := range tests {
@@ -43,9 +43,9 @@ func TestPBRSpecularGlossiness_MarshalJSON(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"default", &PBRSpecularGlossiness{GlossinessFactor: gltf.Float(1), DiffuseFactor: &[4]float32{1, 1, 1, 1}, SpecularFactor: &[3]float32{1, 1, 1}}, []byte(`{}`), false},
+		{"default", &PBRSpecularGlossiness{GlossinessFactor: gltf.Float(1), DiffuseFactor: &[4]float64{1, 1, 1, 1}, SpecularFactor: &[3]float64{1, 1, 1}}, []byte(`{}`), false},
 		{"empty", &PBRSpecularGlossiness{}, []byte(`{}`), false},
-		{"nodefault", &PBRSpecularGlossiness{GlossinessFactor: gltf.Float(0.5), DiffuseFactor: &[4]float32{1, 0.5, 1, 1}, SpecularFactor: &[3]float32{1, 1, 0.5}}, []byte(`{"diffuseFactor":[1,0.5,1,1],"specularFactor":[1,1,0.5],"glossinessFactor":0.5}`), false},
+		{"nodefault", &PBRSpecularGlossiness{GlossinessFactor: gltf.Float(0.5), DiffuseFactor: &[4]float64{1, 0.5, 1, 1}, SpecularFactor: &[3]float64{1, 1, 0.5}}, []byte(`{"diffuseFactor":[1,0.5,1,1],"specularFactor":[1,1,0.5],"glossinessFactor":0.5}`), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestUnmarshal(t *testing.T) {
 		want    interface{}
 		wantErr bool
 	}{
-		{"base", args{[]byte("{}")}, &PBRSpecularGlossiness{DiffuseFactor: &[4]float32{1, 1, 1, 1}, SpecularFactor: &[3]float32{1, 1, 1}, GlossinessFactor: gltf.Float(1)}, false},
+		{"base", args{[]byte("{}")}, &PBRSpecularGlossiness{DiffuseFactor: &[4]float64{1, 1, 1, 1}, SpecularFactor: &[3]float64{1, 1, 1}, GlossinessFactor: gltf.Float(1)}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ext/texturetransform/transform.go
+++ b/ext/texturetransform/transform.go
@@ -9,9 +9,9 @@ import (
 
 var (
 	// DefaultScale defines a scaling that does not modify the size of the object.
-	DefaultScale = [2]float32{1, 1}
-	emptyScale   = [2]float32{0, 0}
-	emptyOffset  = [2]float32{0, 0}
+	DefaultScale = [2]float64{1, 1}
+	emptyScale   = [2]float64{0, 0}
+	emptyOffset  = [2]float64{0, 0}
 )
 
 const (
@@ -32,14 +32,14 @@ func init() {
 
 // TextureTranform can be used in textureInfo to pack many low-res texture into a single large texture atlas.
 type TextureTranform struct {
-	Offset   [2]float32 `json:"offset"`
-	Rotation float32    `json:"rotation,omitempty"`
-	Scale    [2]float32 `json:"scale"`
+	Offset   [2]float64 `json:"offset"`
+	Rotation float64    `json:"rotation,omitempty"`
+	Scale    [2]float64 `json:"scale"`
 	TexCoord *uint32    `json:"texCoord,omitempty"`
 }
 
 // ScaleOrDefault returns the node scale if it represents a valid scale factor, else return the default one.
-func (t *TextureTranform) ScaleOrDefault() [2]float32 {
+func (t *TextureTranform) ScaleOrDefault() [2]float64 {
 	if t.Scale == emptyScale {
 		return DefaultScale
 	}

--- a/ext/texturetransform/transform_test.go
+++ b/ext/texturetransform/transform_test.go
@@ -11,11 +11,11 @@ func TestTextureTranform_ScaleOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		t    *TextureTranform
-		want [2]float32
+		want [2]float64
 	}{
 		{"default", &TextureTranform{Scale: DefaultScale}, DefaultScale},
 		{"zeros", &TextureTranform{Scale: emptyScale}, DefaultScale},
-		{"other", &TextureTranform{Scale: [2]float32{1, 2}}, [2]float32{1, 2}},
+		{"other", &TextureTranform{Scale: [2]float64{1, 2}}, [2]float64{1, 2}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -39,7 +39,7 @@ func TestTextureTranform_UnmarshalJSON(t *testing.T) {
 	}{
 		{"default", new(TextureTranform), args{[]byte("{}")}, &TextureTranform{Scale: DefaultScale}, false},
 		{"nodefault", new(TextureTranform), args{[]byte(`{"offset": [0.1,0.2],"rotation":1.57,"scale":[1, -1],"texCoord":2}`)}, &TextureTranform{
-			Offset: [2]float32{0.1, 0.2}, Rotation: 1.57, Scale: [2]float32{1, -1}, TexCoord: gltf.Index(2),
+			Offset: [2]float64{0.1, 0.2}, Rotation: 1.57, Scale: [2]float64{1, -1}, TexCoord: gltf.Index(2),
 		}, false},
 	}
 	for _, tt := range tests {
@@ -64,7 +64,7 @@ func TestTextureTranform_MarshalJSON(t *testing.T) {
 	}{
 		{"default", &TextureTranform{Scale: DefaultScale}, []byte(`{}`), false},
 		{"empty", &TextureTranform{}, []byte(`{}`), false},
-		{"nodefault", &TextureTranform{Offset: [2]float32{0.1, 0.2}, Rotation: 1.57, Scale: [2]float32{1, -1}, TexCoord: gltf.Index(2)}, []byte(`{"offset":[0.1,0.2],"rotation":1.57,"scale":[1,-1],"texCoord":2}`), false},
+		{"nodefault", &TextureTranform{Offset: [2]float64{0.1, 0.2}, Rotation: 1.57, Scale: [2]float64{1, -1}, TexCoord: gltf.Index(2)}, []byte(`{"offset":[0.1,0.2],"rotation":1.57,"scale":[1,-1],"texCoord":2}`), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gltf.go
+++ b/gltf.go
@@ -12,8 +12,8 @@ func Index(i uint32) *uint32 {
 	return &i
 }
 
-// Float is an utility function that returns a pointer to a float32.
-func Float(val float32) *float32 {
+// Float is an utility function that returns a pointer to a float64.
+func Float(val float64) *float64 {
 	return &val
 }
 
@@ -75,8 +75,8 @@ type Accessor struct {
 	Normalized    bool          `json:"normalized,omitempty"`      // Specifies whether integer data values should be normalized.
 	Count         uint32        `json:"count" validate:"required"` // The number of attributes referenced by this accessor.
 	Type          AccessorType  `json:"type" validate:"lte=6"`
-	Max           []float32     `json:"max,omitempty" validate:"omitempty,lte=16"` // Maximum value of each component in this attribute.
-	Min           []float32     `json:"min,omitempty" validate:"omitempty,lte=16"` // Minimum value of each component in this attribute.
+	Max           []float64     `json:"max,omitempty" validate:"omitempty,lte=16"` // Maximum value of each component in this attribute.
+	Min           []float64     `json:"min,omitempty" validate:"omitempty,lte=16"` // Minimum value of each component in this attribute.
 	Sparse        *Sparse       `json:"sparse,omitempty"`                          // Sparse storage of attributes that deviate from their initialization value.
 }
 
@@ -173,16 +173,16 @@ type Node struct {
 	Camera      *uint32     `json:"camera,omitempty"`
 	Children    []uint32    `json:"children,omitempty" validate:"omitempty,unique"`
 	Skin        *uint32     `json:"skin,omitempty"`
-	Matrix      [16]float32 `json:"matrix"` // A 4x4 transformation matrix stored in column-major order.
+	Matrix      [16]float64 `json:"matrix"` // A 4x4 transformation matrix stored in column-major order.
 	Mesh        *uint32     `json:"mesh,omitempty"`
-	Rotation    [4]float32  `json:"rotation" validate:"omitempty,dive,gte=-1,lte=1"` // The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
-	Scale       [3]float32  `json:"scale"`
-	Translation [3]float32  `json:"translation"`
-	Weights     []float32   `json:"weights,omitempty"` // The weights of the instantiated Morph Target.
+	Rotation    [4]float64  `json:"rotation" validate:"omitempty,dive,gte=-1,lte=1"` // The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
+	Scale       [3]float64  `json:"scale"`
+	Translation [3]float64  `json:"translation"`
+	Weights     []float64   `json:"weights,omitempty"` // The weights of the instantiated Morph Target.
 }
 
 // MatrixOrDefault returns the node matrix if it represents a valid affine matrix, else return the default one.
-func (n *Node) MatrixOrDefault() [16]float32 {
+func (n *Node) MatrixOrDefault() [16]float64 {
 	if n.Matrix == emptyMatrix {
 		return DefaultMatrix
 	}
@@ -190,7 +190,7 @@ func (n *Node) MatrixOrDefault() [16]float32 {
 }
 
 // RotationOrDefault returns the node rotation if it represents a valid quaternion, else return the default one.
-func (n *Node) RotationOrDefault() [4]float32 {
+func (n *Node) RotationOrDefault() [4]float64 {
 	if n.Rotation == emptyRotation {
 		return DefaultRotation
 	}
@@ -198,7 +198,7 @@ func (n *Node) RotationOrDefault() [4]float32 {
 }
 
 // ScaleOrDefault returns the node scale if it represents a valid scale factor, else return the default one.
-func (n *Node) ScaleOrDefault() [3]float32 {
+func (n *Node) ScaleOrDefault() [3]float64 {
 	if n.Scale == emptyScale {
 		return DefaultScale
 	}
@@ -206,7 +206,7 @@ func (n *Node) ScaleOrDefault() [3]float32 {
 }
 
 // TranslationOrDefault returns the node translation.
-func (n *Node) TranslationOrDefault() [3]float32 {
+func (n *Node) TranslationOrDefault() [3]float64 {
 	return n.Translation
 }
 
@@ -233,20 +233,20 @@ type Camera struct {
 type Orthographic struct {
 	Extensions Extensions  `json:"extensions,omitempty"`
 	Extras     interface{} `json:"extras,omitempty"`
-	Xmag       float32     `json:"xmag"`                               // The horizontal magnification of the view.
-	Ymag       float32     `json:"ymag"`                               // The vertical magnification of the view.
-	Zfar       float32     `json:"zfar" validate:"gt=0,gtfield=Znear"` // The distance to the far clipping plane.
-	Znear      float32     `json:"znear" validate:"gte=0"`             // The distance to the near clipping plane.
+	Xmag       float64     `json:"xmag"`                               // The horizontal magnification of the view.
+	Ymag       float64     `json:"ymag"`                               // The vertical magnification of the view.
+	Zfar       float64     `json:"zfar" validate:"gt=0,gtfield=Znear"` // The distance to the far clipping plane.
+	Znear      float64     `json:"znear" validate:"gte=0"`             // The distance to the near clipping plane.
 }
 
 // Perspective camera containing properties to create a perspective projection matrix.
 type Perspective struct {
 	Extensions  Extensions  `json:"extensions,omitempty"`
 	Extras      interface{} `json:"extras,omitempty"`
-	AspectRatio *float32    `json:"aspectRatio,omitempty"`
-	Yfov        float32     `json:"yfov"`           // The vertical field of view in radians.
-	Zfar        *float32    `json:"zfar,omitempty"` // The distance to the far clipping plane.
-	Znear       float32     `json:"znear"`          // The distance to the near clipping plane.
+	AspectRatio *float64    `json:"aspectRatio,omitempty"`
+	Yfov        float64     `json:"yfov"`           // The vertical field of view in radians.
+	Zfar        *float64    `json:"zfar,omitempty"` // The distance to the far clipping plane.
+	Znear       float64     `json:"znear"`          // The distance to the near clipping plane.
 }
 
 // A Mesh is a set of primitives to be rendered. A node can contain one mesh. A node's transform places the mesh in the scene.
@@ -255,7 +255,7 @@ type Mesh struct {
 	Extras     interface{}  `json:"extras,omitempty"`
 	Name       string       `json:"name,omitempty"`
 	Primitives []*Primitive `json:"primitives" validate:"required,gt=0,dive"`
-	Weights    []float32    `json:"weights,omitempty"`
+	Weights    []float64    `json:"weights,omitempty"`
 }
 
 // Primitive defines the geometry to be rendered with the given material.
@@ -278,14 +278,14 @@ type Material struct {
 	NormalTexture        *NormalTexture        `json:"normalTexture,omitempty"`
 	OcclusionTexture     *OcclusionTexture     `json:"occlusionTexture,omitempty"`
 	EmissiveTexture      *TextureInfo          `json:"emissiveTexture,omitempty"`
-	EmissiveFactor       [3]float32            `json:"emissiveFactor,omitempty" validate:"dive,gte=0,lte=1"`
+	EmissiveFactor       [3]float64            `json:"emissiveFactor,omitempty" validate:"dive,gte=0,lte=1"`
 	AlphaMode            AlphaMode             `json:"alphaMode,omitempty" validate:"lte=2"`
-	AlphaCutoff          *float32              `json:"alphaCutoff,omitempty" validate:"omitempty,gte=0"`
+	AlphaCutoff          *float64              `json:"alphaCutoff,omitempty" validate:"omitempty,gte=0"`
 	DoubleSided          bool                  `json:"doubleSided,omitempty"`
 }
 
 // AlphaCutoffOrDefault returns the scale if it is not nil, else return the default one.
-func (m *Material) AlphaCutoffOrDefault() float32 {
+func (m *Material) AlphaCutoffOrDefault() float64 {
 	if m.AlphaCutoff == nil {
 		return 0.5
 	}
@@ -298,11 +298,11 @@ type NormalTexture struct {
 	Extras     interface{} `json:"extras,omitempty"`
 	Index      *uint32     `json:"index,omitempty"`
 	TexCoord   uint32      `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
-	Scale      *float32    `json:"scale,omitempty"`
+	Scale      *float64    `json:"scale,omitempty"`
 }
 
 // ScaleOrDefault returns the scale if it is not nil, else return the default one.
-func (n *NormalTexture) ScaleOrDefault() float32 {
+func (n *NormalTexture) ScaleOrDefault() float64 {
 	if n.Scale == nil {
 		return 1
 	}
@@ -315,11 +315,11 @@ type OcclusionTexture struct {
 	Extras     interface{} `json:"extras,omitempty"`
 	Index      *uint32     `json:"index,omitempty"`
 	TexCoord   uint32      `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
-	Strength   *float32    `json:"strength,omitempty" validate:"omitempty,gte=0,lte=1"`
+	Strength   *float64    `json:"strength,omitempty" validate:"omitempty,gte=0,lte=1"`
 }
 
 // StrengthOrDefault returns the strength if it is not nil, else return the default one.
-func (o *OcclusionTexture) StrengthOrDefault() float32 {
+func (o *OcclusionTexture) StrengthOrDefault() float64 {
 	if o.Strength == nil {
 		return 1
 	}
@@ -330,15 +330,15 @@ func (o *OcclusionTexture) StrengthOrDefault() float32 {
 type PBRMetallicRoughness struct {
 	Extensions               Extensions   `json:"extensions,omitempty"`
 	Extras                   interface{}  `json:"extras,omitempty"`
-	BaseColorFactor          *[4]float32  `json:"baseColorFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
+	BaseColorFactor          *[4]float64  `json:"baseColorFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
 	BaseColorTexture         *TextureInfo `json:"baseColorTexture,omitempty"`
-	MetallicFactor           *float32     `json:"metallicFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
-	RoughnessFactor          *float32     `json:"roughnessFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
+	MetallicFactor           *float64     `json:"metallicFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
+	RoughnessFactor          *float64     `json:"roughnessFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
 	MetallicRoughnessTexture *TextureInfo `json:"metallicRoughnessTexture,omitempty"`
 }
 
 // MetallicFactorOrDefault returns the metallic factor if it is not nil, else return the default one.
-func (p *PBRMetallicRoughness) MetallicFactorOrDefault() float32 {
+func (p *PBRMetallicRoughness) MetallicFactorOrDefault() float64 {
 	if p.MetallicFactor == nil {
 		return 1
 	}
@@ -346,7 +346,7 @@ func (p *PBRMetallicRoughness) MetallicFactorOrDefault() float32 {
 }
 
 // RoughnessFactorOrDefault returns the roughness factor if it is not nil, else return the default one.
-func (p *PBRMetallicRoughness) RoughnessFactorOrDefault() float32 {
+func (p *PBRMetallicRoughness) RoughnessFactorOrDefault() float64 {
 	if p.RoughnessFactor == nil {
 		return 1
 	}
@@ -354,9 +354,9 @@ func (p *PBRMetallicRoughness) RoughnessFactorOrDefault() float32 {
 }
 
 // BaseColorFactorOrDefault returns the base color factor if it is not nil, else return the default one.
-func (p *PBRMetallicRoughness) BaseColorFactorOrDefault() [4]float32 {
+func (p *PBRMetallicRoughness) BaseColorFactorOrDefault() [4]float64 {
 	if p.BaseColorFactor == nil {
-		return [4]float32{1, 1, 1, 1}
+		return [4]float64{1, 1, 1, 1}
 	}
 	return *p.BaseColorFactor
 }

--- a/gltf_test.go
+++ b/gltf_test.go
@@ -116,11 +116,11 @@ func TestNode_MatrixOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		n    *Node
-		want [16]float32
+		want [16]float64
 	}{
 		{"default", &Node{Matrix: DefaultMatrix}, DefaultMatrix},
 		{"zeros", &Node{Matrix: emptyMatrix}, DefaultMatrix},
-		{"other", &Node{Matrix: [16]float32{2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2}}, [16]float32{2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2}},
+		{"other", &Node{Matrix: [16]float64{2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2}}, [16]float64{2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -135,11 +135,11 @@ func TestNode_RotationOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		n    *Node
-		want [4]float32
+		want [4]float64
 	}{
 		{"default", &Node{Rotation: DefaultRotation}, DefaultRotation},
 		{"zeros", &Node{Rotation: emptyRotation}, DefaultRotation},
-		{"other", &Node{Rotation: [4]float32{1, 2, 3, 4}}, [4]float32{1, 2, 3, 4}},
+		{"other", &Node{Rotation: [4]float64{1, 2, 3, 4}}, [4]float64{1, 2, 3, 4}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -154,11 +154,11 @@ func TestNode_ScaleOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		n    *Node
-		want [3]float32
+		want [3]float64
 	}{
 		{"default", &Node{Scale: DefaultScale}, DefaultScale},
 		{"zeros", &Node{Scale: emptyScale}, DefaultScale},
-		{"other", &Node{Scale: [3]float32{1, 2, 3}}, [3]float32{1, 2, 3}},
+		{"other", &Node{Scale: [3]float64{1, 2, 3}}, [3]float64{1, 2, 3}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -173,10 +173,10 @@ func TestNode_TranslationOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		n    *Node
-		want [3]float32
+		want [3]float64
 	}{
 		{"default", &Node{Translation: DefaultTranslation}, DefaultTranslation},
-		{"other", &Node{Translation: [3]float32{1, 2, 3}}, [3]float32{1, 2, 3}},
+		{"other", &Node{Translation: [3]float64{1, 2, 3}}, [3]float64{1, 2, 3}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -191,10 +191,10 @@ func TestPBRMetallicRoughness_BaseColorFactorOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *PBRMetallicRoughness
-		want [4]float32
+		want [4]float64
 	}{
-		{"empty", &PBRMetallicRoughness{}, [4]float32{1, 1, 1, 1}},
-		{"other", &PBRMetallicRoughness{BaseColorFactor: &[4]float32{0.8, 0.8, 0.8, 0.5}}, [4]float32{0.8, 0.8, 0.8, 0.5}},
+		{"empty", &PBRMetallicRoughness{}, [4]float64{1, 1, 1, 1}},
+		{"other", &PBRMetallicRoughness{BaseColorFactor: &[4]float64{0.8, 0.8, 0.8, 0.5}}, [4]float64{0.8, 0.8, 0.8, 0.5}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestOcclusionTexture_StrengthOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		o    *OcclusionTexture
-		want float32
+		want float64
 	}{
 		{"empty", &OcclusionTexture{}, 1},
 		{"other", &OcclusionTexture{Strength: Float(2)}, 2},
@@ -227,7 +227,7 @@ func TestNormalTexture_ScaleOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		n    *NormalTexture
-		want float32
+		want float64
 	}{
 		{"empty", &NormalTexture{}, 1},
 		{"other", &NormalTexture{Scale: Float(2)}, 2},
@@ -245,7 +245,7 @@ func TestMaterial_AlphaCutoffOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		m    *Material
-		want float32
+		want float64
 	}{
 		{"empty", &Material{}, 0.5},
 		{"other", &Material{AlphaCutoff: Float(2)}, 2},
@@ -263,7 +263,7 @@ func TestPBRMetallicRoughness_MetallicFactorOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *PBRMetallicRoughness
-		want float32
+		want float64
 	}{
 		{"empty", &PBRMetallicRoughness{}, 1},
 		{"other", &PBRMetallicRoughness{MetallicFactor: Float(2)}, 2},
@@ -281,7 +281,7 @@ func TestPBRMetallicRoughness_RoughnessFactorOrDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *PBRMetallicRoughness
-		want float32
+		want float64
 	}{
 		{"empty", &PBRMetallicRoughness{}, 1},
 		{"other", &PBRMetallicRoughness{RoughnessFactor: Float(2)}, 2},

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -113,13 +113,13 @@ func WritePosition(doc *gltf.Document, data [][3]float32) uint32 {
 	return index
 }
 
-func minMaxFloat32(data [][3]float32) ([3]float32, [3]float32) {
-	min := [3]float32{math.MaxFloat32, math.MaxFloat32, math.MaxFloat32}
-	max := [3]float32{-math.MaxFloat32, -math.MaxFloat32, -math.MaxFloat32}
+func minMaxFloat32(data [][3]float32) ([3]float64, [3]float64) {
+	min := [3]float64{math.MaxFloat64, math.MaxFloat64, math.MaxFloat64}
+	max := [3]float64{-math.MaxFloat64, -math.MaxFloat64, -math.MaxFloat64}
 	for _, v := range data {
 		for i, x := range v {
-			min[i] = float32(math.Min(float64(min[i]), float64(x)))
-			max[i] = float32(math.Max(float64(max[i]), float64(x)))
+			min[i] = math.Min(float64(min[i]), float64(x))
+			max[i] = math.Max(float64(max[i]), float64(x))
 		}
 	}
 	return min, max

--- a/modeler/write_test.go
+++ b/modeler/write_test.go
@@ -73,7 +73,7 @@ func TestWriteAttributesInterleaved(t *testing.T) {
 		t.Errorf("TestWriteAttributesInterleaved() = %v", diff)
 	}
 	accs := []*gltf.Accessor{
-		{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec3, Min: []float32{0, 0, -1}, Max: []float32{1, 2, 3}},
+		{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec3, Min: []float64{0, 0, -1}, Max: []float64{1, 2, 3}},
 		{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec3, ByteOffset: 12},
 		{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec4, ByteOffset: 24},
 		{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec2, ByteOffset: 40},
@@ -306,7 +306,7 @@ func TestWritePosition(t *testing.T) {
 		}, args{[][3]float32{{1, 2, 3}, {0, 0, -1}}}, 1, &gltf.Document{
 			Accessors: []*gltf.Accessor{
 				{},
-				{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentFloat, Max: []float32{1, 2, 3}, Min: []float32{0, 0, -1}},
+				{BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentFloat, Max: []float64{1, 2, 3}, Min: []float64{0, 0, -1}},
 			},
 			BufferViews: []*gltf.BufferView{
 				{ByteLength: 24, Target: gltf.TargetArrayBuffer},


### PR DESCRIPTION
Using float64 for json properties yields better accuracy while having a negligible file size impact, as the json chunk is a tiny fraction of the binary buffer.

Closes #73.