### PR TITLE
Rewrite interface{} to any

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ func init() {
     gltf.RegisterExtension(ExtensionName, Unmarshal)
 }
 
-func Unmarshal(data []byte) (interface{}, error) {
+func Unmarshal(data []byte) (any, error) {
     foo := new(Foo)
     err := json.Unmarshal(data, foo)
     return foo, err

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -9,22 +9,22 @@
 // they all follow the same `generic` interface, and the only difference is the
 // type of the value:
 //
-// type Component interface {
-//   Scalar([]byte) interface{}
-//   Vec2([]byte) [2]interface{}
-//   Vec3([]byte) [2]interface{}
-//   Vec4([]byte) [2]interface{}
-//   Mat2([]byte) [2][2]interface{}
-//   Mat3([]byte) [3][3]interface{}
-//   Mat4([]byte) [4][4]interface{}
-//   PutScalar([]byte, interface{})
-//   PutVec2([]byte, [2]interface{})
-//   PutVec3([]byte, [3]interface{})
-//   PutVec4([]byte, [4]interface{})
-//   PutMat2([]byte, [2][2]interface{})
-//   PutMat3([]byte, [3][3]interface{})
-//   PutMat4([]byte, [4][4]interface{})
-// }
+//	type Component interface {
+//	  Scalar([]byte) any
+//	  Vec2([]byte) [2]any
+//	  Vec3([]byte) [2]any
+//	  Vec4([]byte) [2]any
+//	  Mat2([]byte) [2][2]any
+//	  Mat3([]byte) [3][3]any
+//	  Mat4([]byte) [4][4]any
+//	  PutScalar([]byte, any)
+//	  PutVec2([]byte, [2]any)
+//	  PutVec3([]byte, [3]any)
+//	  PutVec4([]byte, [4]any)
+//	  PutMat2([]byte, [2][2]any)
+//	  PutMat3([]byte, [3][3]any)
+//	  PutMat4([]byte, [4][4]any)
+//	}
 //
 // This package favors simplicity and compliance over efficiency,
 // but it is still an order of magnitude more performant than using the built-in

--- a/binary/encode.go
+++ b/binary/encode.go
@@ -14,7 +14,7 @@ import (
 //
 // Data should be a slice of glTF predefined fixed-size types.
 // If data length is greater than the length of b, Read returns io.ErrShortBuffer.
-func Read(b []byte, byteStride uint32, data interface{}) error {
+func Read(b []byte, byteStride uint32, data any) error {
 	c, t, n := Type(data)
 	size := gltf.SizeOfElement(c, t)
 	if byteStride == 0 {
@@ -222,7 +222,7 @@ func Read(b []byte, byteStride uint32, data interface{}) error {
 //
 // Data must be a slice of glTF predefined fixed-size types,
 // else it fallbacks to `encoding/binary.Write`.
-func Write(b []byte, stride uint32, data interface{}) error {
+func Write(b []byte, stride uint32, data any) error {
 	c, t, n := Type(data)
 	if n == 0 {
 		return binary.Write(bytes.NewBuffer(b), binary.LittleEndian, data)

--- a/binary/encode_test.go
+++ b/binary/encode_test.go
@@ -49,12 +49,12 @@ func buildBufferF(n int) []byte {
 func TestRead(t *testing.T) {
 	type args struct {
 		b    []byte
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{"small", args{[]byte{0, 0}, []int8{1, 2, 3}}, []int8{0, 0}, true},
@@ -179,7 +179,7 @@ func TestRead(t *testing.T) {
 func TestWrite(t *testing.T) {
 	type args struct {
 		n    int
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string

--- a/binary/slice.go
+++ b/binary/slice.go
@@ -11,7 +11,7 @@ import (
 // MakeSliceBuffer returns the slice type associated with c and t and with the given element count.
 // If the buffer is an slice which type matches with the expected by the acr then it will
 // be used as backing slice.
-func MakeSliceBuffer(c gltf.ComponentType, t gltf.AccessorType, count uint32, buffer interface{}) interface{} {
+func MakeSliceBuffer(c gltf.ComponentType, t gltf.AccessorType, count uint32, buffer any) any {
 	if buffer == nil {
 		return MakeSlice(c, t, count)
 	}
@@ -32,7 +32,7 @@ func MakeSliceBuffer(c gltf.ComponentType, t gltf.AccessorType, count uint32, bu
 // MakeSlice returns the slice type associated with c and t and with the given element count.
 // For example, if c is gltf.ComponentFloat and t is gltf.AccessorVec3
 // then MakeSlice(c, t, 5) is equivalent to make([][3]float32, 5).
-func MakeSlice(c gltf.ComponentType, t gltf.AccessorType, count uint32) interface{} {
+func MakeSlice(c gltf.ComponentType, t gltf.AccessorType, count uint32) any {
 	var tp reflect.Type
 	switch c {
 	case gltf.ComponentUbyte:
@@ -68,7 +68,7 @@ func MakeSlice(c gltf.ComponentType, t gltf.AccessorType, count uint32) interfac
 
 // Type returns the associated glTF type data.
 // It panics if data is not an slice.
-func Type(data interface{}) (c gltf.ComponentType, t gltf.AccessorType, count uint32) {
+func Type(data any) (c gltf.ComponentType, t gltf.AccessorType, count uint32) {
 	v := reflect.ValueOf(data)
 	if v.Kind() != reflect.Slice {
 		panic(fmt.Sprintf("go3mf: binary.Type expecting a slice but got %s", v.Kind()))

--- a/binary/slice_test.go
+++ b/binary/slice_test.go
@@ -16,7 +16,7 @@ func TestMakeSlice(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want interface{}
+		want any
 	}{
 		// Scalar
 		{"[]uint8", args{gltf.ComponentUbyte, gltf.AccessorScalar, 5}, make([]uint8, 5)},
@@ -82,12 +82,12 @@ func TestMakeSliceBuffer(t *testing.T) {
 		c      gltf.ComponentType
 		t      gltf.AccessorType
 		count  uint32
-		buffer interface{}
+		buffer any
 	}
 	tests := []struct {
 		name string
 		args args
-		want interface{}
+		want any
 	}{
 		{"nil buffer", args{gltf.ComponentUbyte, gltf.AccessorVec2, 2, nil}, make([][2]uint8, 2)},
 		{"empty buffer", args{gltf.ComponentUbyte, gltf.AccessorVec2, 2, make([][2]uint8, 0)}, make([][2]uint8, 2)},

--- a/encode_test.go
+++ b/encode_test.go
@@ -676,7 +676,7 @@ func (f *fakeExt) UnmarshalJSON(data []byte) error {
 }
 
 func TestExtensions_UnmarshalJSON(t *testing.T) {
-	RegisterExtension("fake_ext", func(data []byte) (interface{}, error) {
+	RegisterExtension("fake_ext", func(data []byte) (any, error) {
 		e := new(fakeExt)
 		err := json.Unmarshal(data, e)
 		return e, err

--- a/ext/lightspuntual/lightspuntual.go
+++ b/ext/lightspuntual/lightspuntual.go
@@ -25,7 +25,7 @@ type envelop struct {
 }
 
 // Unmarshal decodes the json data into the correct type.
-func Unmarshal(data []byte) (interface{}, error) {
+func Unmarshal(data []byte) (any, error) {
 	var env envelop
 	if err := json.Unmarshal([]byte(data), &env); err != nil {
 		return nil, err

--- a/ext/lightspuntual/lightspuntual_test.go
+++ b/ext/lightspuntual/lightspuntual_test.go
@@ -114,7 +114,7 @@ func TestUnmarshal(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{"error", args{[]byte(`{"light: 1}`)}, nil, true},

--- a/ext/specular/specular.go
+++ b/ext/specular/specular.go
@@ -13,7 +13,7 @@ const (
 )
 
 // Unmarshal decodes the json data into the correct type.
-func Unmarshal(data []byte) (interface{}, error) {
+func Unmarshal(data []byte) (any, error) {
 	pbr := new(PBRSpecularGlossiness)
 	err := json.Unmarshal(data, pbr)
 	return pbr, err

--- a/ext/specular/specular_test.go
+++ b/ext/specular/specular_test.go
@@ -68,7 +68,7 @@ func TestUnmarshal(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{"base", args{[]byte("{}")}, &PBRSpecularGlossiness{DiffuseFactor: &[4]float64{1, 1, 1, 1}, SpecularFactor: &[3]float64{1, 1, 1}, GlossinessFactor: gltf.Float(1)}, false},

--- a/ext/texturetransform/transform.go
+++ b/ext/texturetransform/transform.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Unmarshal decodes the json data into the correct type.
-func Unmarshal(data []byte) (interface{}, error) {
+func Unmarshal(data []byte) (any, error) {
 	t := new(TextureTranform)
 	err := json.Unmarshal(data, t)
 	return t, err

--- a/ext/texturetransform/transform_test.go
+++ b/ext/texturetransform/transform_test.go
@@ -87,7 +87,7 @@ func TestUnmarshal(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{"base", args{[]byte("{}")}, &TextureTranform{Scale: DefaultScale}, false},

--- a/ext/unlit/unlit.go
+++ b/ext/unlit/unlit.go
@@ -12,7 +12,7 @@ const (
 )
 
 // Unmarshal decodes the json data into the correct type.
-func Unmarshal(data []byte) (interface{}, error) {
+func Unmarshal(data []byte) (any, error) {
 	u := new(Unlit)
 	err := json.Unmarshal(data, u)
 	return u, err
@@ -25,7 +25,7 @@ func init() {
 // Unlit defines an unlit shading model.
 // When present, the extension indicates that a material should be unlit.
 // Additional properties on the extension object are allowed, but may lead to undefined behaviour in conforming viewers.
-type Unlit map[string]interface{}
+type Unlit map[string]any
 
 // UnmarshalJSON unmarshal the pbr with the correct default values.
 func (u *Unlit) UnmarshalJSON(data []byte) error {

--- a/ext/unlit/unlit_test.go
+++ b/ext/unlit/unlit_test.go
@@ -43,7 +43,7 @@ func TestUnmarshal(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{"base", args{[]byte("{}")}, &Unlit{}, false},

--- a/gltf.go
+++ b/gltf.go
@@ -19,18 +19,18 @@ func Float(val float64) *float64 {
 
 // An Asset is metadata about the glTF asset.
 type Asset struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Copyright  string      `json:"copyright,omitempty"`         // A copyright message suitable for display to credit the content creator.
-	Generator  string      `json:"generator,omitempty"`         // Tool that generated this glTF model. Useful for debugging.
-	Version    string      `json:"version" validate:"required"` // The glTF version that this asset targets.
-	MinVersion string      `json:"minVersion,omitempty"`        // The minimum glTF version that this asset targets.
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Copyright  string     `json:"copyright,omitempty"`         // A copyright message suitable for display to credit the content creator.
+	Generator  string     `json:"generator,omitempty"`         // Tool that generated this glTF model. Useful for debugging.
+	Version    string     `json:"version" validate:"required"` // The glTF version that this asset targets.
+	MinVersion string     `json:"minVersion,omitempty"`        // The minimum glTF version that this asset targets.
 }
 
 // Document defines the root object for a glTF asset.
 type Document struct {
 	Extensions         Extensions    `json:"extensions,omitempty"`
-	Extras             interface{}   `json:"extras,omitempty"`
+	Extras             any           `json:"extras,omitempty"`
 	ExtensionsUsed     []string      `json:"extensionsUsed,omitempty"`
 	ExtensionsRequired []string      `json:"extensionsRequired,omitempty"`
 	Accessors          []*Accessor   `json:"accessors,omitempty" validate:"dive"`
@@ -67,7 +67,7 @@ func NewDocument() *Document {
 // similar to how WebGL's vertexAttribPointer() defines an attribute in a buffer.
 type Accessor struct {
 	Extensions    Extensions    `json:"extensions,omitempty"`
-	Extras        interface{}   `json:"extras,omitempty"`
+	Extras        any           `json:"extras,omitempty"`
 	Name          string        `json:"name,omitempty"`
 	BufferView    *uint32       `json:"bufferView,omitempty"`
 	ByteOffset    uint32        `json:"byteOffset,omitempty"`
@@ -83,7 +83,7 @@ type Accessor struct {
 // Sparse storage of attributes that deviate from their initialization value.
 type Sparse struct {
 	Extensions Extensions    `json:"extensions,omitempty"`
-	Extras     interface{}   `json:"extras,omitempty"`
+	Extras     any           `json:"extras,omitempty"`
 	Count      uint32        `json:"count" validate:"gte=1"` // Number of entries stored in the sparse array.
 	Indices    SparseIndices `json:"indices"`                // Index array of size count that points to those accessor attributes that deviate from their initialization value.
 	Values     SparseValues  `json:"values"`                 // Array of size count times number of components, storing the displaced accessor attributes pointed by indices.
@@ -91,16 +91,16 @@ type Sparse struct {
 
 // SparseValues stores the displaced accessor attributes pointed by accessor.sparse.indices.
 type SparseValues struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	BufferView uint32      `json:"bufferView"`
-	ByteOffset uint32      `json:"byteOffset,omitempty"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	BufferView uint32     `json:"bufferView"`
+	ByteOffset uint32     `json:"byteOffset,omitempty"`
 }
 
 // SparseIndices defines the indices of those attributes that deviate from their initialization value.
 type SparseIndices struct {
 	Extensions    Extensions    `json:"extensions,omitempty"`
-	Extras        interface{}   `json:"extras,omitempty"`
+	Extras        any           `json:"extras,omitempty"`
 	BufferView    uint32        `json:"bufferView"`
 	ByteOffset    uint32        `json:"byteOffset,omitempty"`
 	ComponentType ComponentType `json:"componentType" validate:"oneof=2 4 5"`
@@ -110,12 +110,12 @@ type SparseIndices struct {
 // If Data length is 0 and the Buffer is an external resource the Data won't be flushed,
 // which can be useful when there is no need to load data in memory.
 type Buffer struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	URI        string      `json:"uri,omitempty" validate:"omitempty"`
-	ByteLength uint32      `json:"byteLength" validate:"required"`
-	Data       []byte      `json:"-"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	URI        string     `json:"uri,omitempty" validate:"omitempty"`
+	ByteLength uint32     `json:"byteLength" validate:"required"`
+	Data       []byte     `json:"-"`
 }
 
 // IsEmbeddedResource returns true if the buffer points to an embedded resource.
@@ -146,29 +146,29 @@ func (b *Buffer) marshalData() ([]byte, error) {
 
 // BufferView is a view into a buffer generally representing a subset of the buffer.
 type BufferView struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Buffer     uint32      `json:"buffer"`
-	ByteOffset uint32      `json:"byteOffset,omitempty"`
-	ByteLength uint32      `json:"byteLength" validate:"required"`
-	ByteStride uint32      `json:"byteStride,omitempty" validate:"omitempty,gte=4,lte=252"`
-	Target     Target      `json:"target,omitempty" validate:"omitempty,oneof=34962 34963"`
-	Name       string      `json:"name,omitempty"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Buffer     uint32     `json:"buffer"`
+	ByteOffset uint32     `json:"byteOffset,omitempty"`
+	ByteLength uint32     `json:"byteLength" validate:"required"`
+	ByteStride uint32     `json:"byteStride,omitempty" validate:"omitempty,gte=4,lte=252"`
+	Target     Target     `json:"target,omitempty" validate:"omitempty,oneof=34962 34963"`
+	Name       string     `json:"name,omitempty"`
 }
 
 // The Scene contains a list of root nodes.
 type Scene struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	Nodes      []uint32    `json:"nodes,omitempty" validate:"omitempty,unique"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	Nodes      []uint32   `json:"nodes,omitempty" validate:"omitempty,unique"`
 }
 
 // A Node in the node hierarchy.
 // It can have either a matrix or any combination of translation/rotation/scale (TRS) properties.
 type Node struct {
 	Extensions  Extensions  `json:"extensions,omitempty"`
-	Extras      interface{} `json:"extras,omitempty"`
+	Extras      any         `json:"extras,omitempty"`
 	Name        string      `json:"name,omitempty"`
 	Camera      *uint32     `json:"camera,omitempty"`
 	Children    []uint32    `json:"children,omitempty" validate:"omitempty,unique"`
@@ -212,18 +212,18 @@ func (n *Node) TranslationOrDefault() [3]float64 {
 
 // Skin defines joints and matrices.
 type Skin struct {
-	Extensions          Extensions  `json:"extensions,omitempty"`
-	Extras              interface{} `json:"extras,omitempty"`
-	Name                string      `json:"name,omitempty"`
-	InverseBindMatrices *uint32     `json:"inverseBindMatrices,omitempty"`      // The index of the accessor containing the floating-point 4x4 inverse-bind matrices.
-	Skeleton            *uint32     `json:"skeleton,omitempty"`                 // The index of the node used as a skeleton root. When undefined, joints transforms resolve to scene root.
-	Joints              []uint32    `json:"joints" validate:"omitempty,unique"` // Indices of skeleton nodes, used as joints in this skin.
+	Extensions          Extensions `json:"extensions,omitempty"`
+	Extras              any        `json:"extras,omitempty"`
+	Name                string     `json:"name,omitempty"`
+	InverseBindMatrices *uint32    `json:"inverseBindMatrices,omitempty"`      // The index of the accessor containing the floating-point 4x4 inverse-bind matrices.
+	Skeleton            *uint32    `json:"skeleton,omitempty"`                 // The index of the node used as a skeleton root. When undefined, joints transforms resolve to scene root.
+	Joints              []uint32   `json:"joints" validate:"omitempty,unique"` // Indices of skeleton nodes, used as joints in this skin.
 }
 
 // A Camera projection. A node can reference a camera to apply a transform to place the camera in the scene.
 type Camera struct {
 	Extensions   Extensions    `json:"extensions,omitempty"`
-	Extras       interface{}   `json:"extras,omitempty"`
+	Extras       any           `json:"extras,omitempty"`
 	Name         string        `json:"name,omitempty"`
 	Orthographic *Orthographic `json:"orthographic,omitempty"`
 	Perspective  *Perspective  `json:"perspective,omitempty"`
@@ -231,28 +231,28 @@ type Camera struct {
 
 // Orthographic camera containing properties to create an orthographic projection matrix.
 type Orthographic struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Xmag       float64     `json:"xmag"`                               // The horizontal magnification of the view.
-	Ymag       float64     `json:"ymag"`                               // The vertical magnification of the view.
-	Zfar       float64     `json:"zfar" validate:"gt=0,gtfield=Znear"` // The distance to the far clipping plane.
-	Znear      float64     `json:"znear" validate:"gte=0"`             // The distance to the near clipping plane.
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Xmag       float64    `json:"xmag"`                               // The horizontal magnification of the view.
+	Ymag       float64    `json:"ymag"`                               // The vertical magnification of the view.
+	Zfar       float64    `json:"zfar" validate:"gt=0,gtfield=Znear"` // The distance to the far clipping plane.
+	Znear      float64    `json:"znear" validate:"gte=0"`             // The distance to the near clipping plane.
 }
 
 // Perspective camera containing properties to create a perspective projection matrix.
 type Perspective struct {
-	Extensions  Extensions  `json:"extensions,omitempty"`
-	Extras      interface{} `json:"extras,omitempty"`
-	AspectRatio *float64    `json:"aspectRatio,omitempty"`
-	Yfov        float64     `json:"yfov"`           // The vertical field of view in radians.
-	Zfar        *float64    `json:"zfar,omitempty"` // The distance to the far clipping plane.
-	Znear       float64     `json:"znear"`          // The distance to the near clipping plane.
+	Extensions  Extensions `json:"extensions,omitempty"`
+	Extras      any        `json:"extras,omitempty"`
+	AspectRatio *float64   `json:"aspectRatio,omitempty"`
+	Yfov        float64    `json:"yfov"`           // The vertical field of view in radians.
+	Zfar        *float64   `json:"zfar,omitempty"` // The distance to the far clipping plane.
+	Znear       float64    `json:"znear"`          // The distance to the near clipping plane.
 }
 
 // A Mesh is a set of primitives to be rendered. A node can contain one mesh. A node's transform places the mesh in the scene.
 type Mesh struct {
 	Extensions Extensions   `json:"extensions,omitempty"`
-	Extras     interface{}  `json:"extras,omitempty"`
+	Extras     any          `json:"extras,omitempty"`
 	Name       string       `json:"name,omitempty"`
 	Primitives []*Primitive `json:"primitives" validate:"required,gt=0,dive"`
 	Weights    []float64    `json:"weights,omitempty"`
@@ -261,7 +261,7 @@ type Mesh struct {
 // Primitive defines the geometry to be rendered with the given material.
 type Primitive struct {
 	Extensions Extensions    `json:"extensions,omitempty"`
-	Extras     interface{}   `json:"extras,omitempty"`
+	Extras     any           `json:"extras,omitempty"`
 	Attributes Attribute     `json:"attributes"`
 	Indices    *uint32       `json:"indices,omitempty"` // The index of the accessor that contains the indices.
 	Material   *uint32       `json:"material,omitempty"`
@@ -272,7 +272,7 @@ type Primitive struct {
 // The Material appearance of a primitive.
 type Material struct {
 	Extensions           Extensions            `json:"extensions,omitempty"`
-	Extras               interface{}           `json:"extras,omitempty"`
+	Extras               any                   `json:"extras,omitempty"`
 	Name                 string                `json:"name,omitempty"`
 	PBRMetallicRoughness *PBRMetallicRoughness `json:"pbrMetallicRoughness,omitempty"`
 	NormalTexture        *NormalTexture        `json:"normalTexture,omitempty"`
@@ -294,11 +294,11 @@ func (m *Material) AlphaCutoffOrDefault() float64 {
 
 // A NormalTexture references to a normal texture.
 type NormalTexture struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Index      *uint32     `json:"index,omitempty"`
-	TexCoord   uint32      `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
-	Scale      *float64    `json:"scale,omitempty"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Index      *uint32    `json:"index,omitempty"`
+	TexCoord   uint32     `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
+	Scale      *float64   `json:"scale,omitempty"`
 }
 
 // ScaleOrDefault returns the scale if it is not nil, else return the default one.
@@ -311,11 +311,11 @@ func (n *NormalTexture) ScaleOrDefault() float64 {
 
 // An OcclusionTexture references to an occlusion texture
 type OcclusionTexture struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Index      *uint32     `json:"index,omitempty"`
-	TexCoord   uint32      `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
-	Strength   *float64    `json:"strength,omitempty" validate:"omitempty,gte=0,lte=1"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Index      *uint32    `json:"index,omitempty"`
+	TexCoord   uint32     `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
+	Strength   *float64   `json:"strength,omitempty" validate:"omitempty,gte=0,lte=1"`
 }
 
 // StrengthOrDefault returns the strength if it is not nil, else return the default one.
@@ -329,7 +329,7 @@ func (o *OcclusionTexture) StrengthOrDefault() float64 {
 // PBRMetallicRoughness defines a set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
 type PBRMetallicRoughness struct {
 	Extensions               Extensions   `json:"extensions,omitempty"`
-	Extras                   interface{}  `json:"extras,omitempty"`
+	Extras                   any          `json:"extras,omitempty"`
 	BaseColorFactor          *[4]float64  `json:"baseColorFactor,omitempty" validate:"omitempty,dive,gte=0,lte=1"`
 	BaseColorTexture         *TextureInfo `json:"baseColorTexture,omitempty"`
 	MetallicFactor           *float64     `json:"metallicFactor,omitempty" validate:"omitempty,gte=0,lte=1"`
@@ -363,25 +363,25 @@ func (p *PBRMetallicRoughness) BaseColorFactorOrDefault() [4]float64 {
 
 // TextureInfo references to a texture.
 type TextureInfo struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Index      uint32      `json:"index"`
-	TexCoord   uint32      `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Index      uint32     `json:"index"`
+	TexCoord   uint32     `json:"texCoord,omitempty"` // The index of texture's TEXCOORD attribute used for texture coordinate mapping.
 }
 
 // A Texture and its sampler.
 type Texture struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	Sampler    *uint32     `json:"sampler,omitempty"`
-	Source     *uint32     `json:"source,omitempty"`
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	Sampler    *uint32    `json:"sampler,omitempty"`
+	Source     *uint32    `json:"source,omitempty"`
 }
 
 // Sampler of a texture for filtering and wrapping modes.
 type Sampler struct {
 	Extensions Extensions   `json:"extensions,omitempty"`
-	Extras     interface{}  `json:"extras,omitempty"`
+	Extras     any          `json:"extras,omitempty"`
 	Name       string       `json:"name,omitempty"`
 	MagFilter  MagFilter    `json:"magFilter,omitempty" validate:"lte=1"`
 	MinFilter  MinFilter    `json:"minFilter,omitempty" validate:"lte=5"`
@@ -392,12 +392,12 @@ type Sampler struct {
 // Image data used to create a texture. Image can be referenced by URI or bufferView index.
 // mimeType is required in the latter case.
 type Image struct {
-	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	URI        string      `json:"uri,omitempty" validate:"omitempty"`
-	MimeType   string      `json:"mimeType,omitempty" validate:"omitempty,oneof=image/jpeg image/png"` // Manadatory if BufferView is defined.
-	BufferView *uint32     `json:"bufferView,omitempty"`                                               // Use this instead of the image's uri property.
+	Extensions Extensions `json:"extensions,omitempty"`
+	Extras     any        `json:"extras,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	URI        string     `json:"uri,omitempty" validate:"omitempty"`
+	MimeType   string     `json:"mimeType,omitempty" validate:"omitempty,oneof=image/jpeg image/png"` // Manadatory if BufferView is defined.
+	BufferView *uint32    `json:"bufferView,omitempty"`                                               // Use this instead of the image's uri property.
 }
 
 // IsEmbeddedResource returns true if the buffer points to an embedded resource.
@@ -424,7 +424,7 @@ func (im *Image) MarshalData() ([]byte, error) {
 // An Animation keyframe.
 type Animation struct {
 	Extensions Extensions          `json:"extensions,omitempty"`
-	Extras     interface{}         `json:"extras,omitempty"`
+	Extras     any                 `json:"extras,omitempty"`
 	Name       string              `json:"name,omitempty"`
 	Channels   []*Channel          `json:"channels" validate:"required,gt=0,dive"`
 	Samplers   []*AnimationSampler `json:"samplers" validate:"required,gt=0,dive"`
@@ -433,7 +433,7 @@ type Animation struct {
 // AnimationSampler combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
 type AnimationSampler struct {
 	Extensions    Extensions    `json:"extensions,omitempty"`
-	Extras        interface{}   `json:"extras,omitempty"`
+	Extras        any           `json:"extras,omitempty"`
 	Input         uint32        `json:"input"` // The index of an accessor containing keyframe input values.
 	Interpolation Interpolation `json:"interpolation,omitempty" validate:"lte=2"`
 	Output        uint32        `json:"output"` // The index of an accessor containing keyframe output values.
@@ -442,7 +442,7 @@ type AnimationSampler struct {
 // The Channel targets an animation's sampler at a node's property.
 type Channel struct {
 	Extensions Extensions    `json:"extensions,omitempty"`
-	Extras     interface{}   `json:"extras,omitempty"`
+	Extras     any           `json:"extras,omitempty"`
 	Sampler    *uint32       `json:"sampler,omitempty"`
 	Target     ChannelTarget `json:"target"`
 }
@@ -454,7 +454,7 @@ type Channel struct {
 // For the "scale" property, the values are the scaling factors along the x, y, and z axes.
 type ChannelTarget struct {
 	Extensions Extensions  `json:"extensions,omitempty"`
-	Extras     interface{} `json:"extras,omitempty"`
+	Extras     any         `json:"extras,omitempty"`
 	Node       *uint32     `json:"node,omitempty"`
 	Path       TRSProperty `json:"path" validate:"lte=4"`
 }
@@ -462,23 +462,23 @@ type ChannelTarget struct {
 // Extensions is map where the keys are the extension identifiers and the values are the extensions payloads.
 // If a key matches with one of the supported extensions the value will be marshalled as a pointer to the extension struct.
 // If a key does not match with any of the supported extensions the value will be a json.RawMessage so its decoding can be delayed.
-type Extensions map[string]interface{}
+type Extensions map[string]any
 
 var (
 	extMu      sync.RWMutex
-	extensions = make(map[string]func([]byte) (interface{}, error))
+	extensions = make(map[string]func([]byte) (any, error))
 )
 
 // RegisterExtension registers a function that returns a new extension of the given
 // byte array. This is intended to be called from the init function in
 // packages that implement extensions.
-func RegisterExtension(key string, f func([]byte) (interface{}, error)) {
+func RegisterExtension(key string, f func([]byte) (any, error)) {
 	extMu.Lock()
 	defer extMu.Unlock()
 	extensions[key] = f
 }
 
-func queryExtension(key string) (func([]byte) (interface{}, error), bool) {
+func queryExtension(key string) (func([]byte) (any, error), bool) {
 	extMu.RLock()
 	ext, ok := extensions[key]
 	extMu.RUnlock()

--- a/modeler/read.go
+++ b/modeler/read.go
@@ -22,7 +22,7 @@ import (
 //
 // ReadAccessor is safe to use even with malformed documents.
 // If that happens it will return an error instead of panic.
-func ReadAccessor(doc *gltf.Document, acr *gltf.Accessor, buffer interface{}) (interface{}, error) {
+func ReadAccessor(doc *gltf.Document, acr *gltf.Accessor, buffer any) (any, error) {
 	if acr.BufferView == nil && acr.Sparse == nil {
 		return nil, nil
 	}

--- a/modeler/read_test.go
+++ b/modeler/read_test.go
@@ -108,7 +108,7 @@ func TestReadAccessor(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{"nodata", args{&gltf.Document{}, &gltf.Accessor{}}, nil, false},

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -19,7 +19,7 @@ import (
 // WriteIndices adds a new INDICES accessor to doc
 // and fills the last buffer with data.
 // If success it returns the index of the new accessor.
-func WriteIndices(doc *gltf.Document, data interface{}) uint32 {
+func WriteIndices(doc *gltf.Document, data any) uint32 {
 	switch data.(type) {
 	case []uint16, []uint32:
 	default:
@@ -45,14 +45,14 @@ func WriteTangent(doc *gltf.Document, data [][4]float32) uint32 {
 // WriteTextureCoord adds a new TEXTURECOORD accessor to doc
 // and fills the last buffer with data.
 // If success it returns the index of the new accessor.
-func WriteTextureCoord(doc *gltf.Document, data interface{}) uint32 {
+func WriteTextureCoord(doc *gltf.Document, data any) uint32 {
 	normalized := checkTextureCoord(data)
 	index := WriteAccessor(doc, gltf.TargetArrayBuffer, data)
 	doc.Accessors[index].Normalized = normalized
 	return index
 }
 
-func checkTextureCoord(data interface{}) bool {
+func checkTextureCoord(data any) bool {
 	var normalized bool
 	switch data.(type) {
 	case [][2]uint8, [][2]uint16:
@@ -67,14 +67,14 @@ func checkTextureCoord(data interface{}) bool {
 // WriteWeights adds a new WEIGHTS accessor to doc
 // and fills the last buffer with data.
 // If success it returns the index of the new accessor.
-func WriteWeights(doc *gltf.Document, data interface{}) uint32 {
+func WriteWeights(doc *gltf.Document, data any) uint32 {
 	normalized := checkWeights(data)
 	index := WriteAccessor(doc, gltf.TargetArrayBuffer, data)
 	doc.Accessors[index].Normalized = normalized
 	return index
 }
 
-func checkWeights(data interface{}) bool {
+func checkWeights(data any) bool {
 	var normalized bool
 	switch data.(type) {
 	case [][4]uint8, [][4]uint16:
@@ -89,12 +89,12 @@ func checkWeights(data interface{}) bool {
 // WriteJoints adds a new JOINTS accessor to doc
 // and fills the last buffer with data.
 // If success it returns the index of the new accessor.
-func WriteJoints(doc *gltf.Document, data interface{}) uint32 {
+func WriteJoints(doc *gltf.Document, data any) uint32 {
 	checkJoints(data)
 	return WriteAccessor(doc, gltf.TargetArrayBuffer, data)
 }
 
-func checkJoints(data interface{}) {
+func checkJoints(data any) {
 	switch data.(type) {
 	case [][4]uint8, [][4]uint16:
 	default:
@@ -128,14 +128,14 @@ func minMaxFloat32(data [][3]float32) ([3]float64, [3]float64) {
 // WriteColor adds a new COLOR accessor to doc
 // and fills the buffer with data.
 // If success it returns the index of the new accessor.
-func WriteColor(doc *gltf.Document, data interface{}) uint32 {
+func WriteColor(doc *gltf.Document, data any) uint32 {
 	normalized := checkColor(data)
 	index := WriteAccessor(doc, gltf.TargetArrayBuffer, data)
 	doc.Accessors[index].Normalized = normalized
 	return index
 }
 
-func checkColor(data interface{}) bool {
+func checkColor(data any) bool {
 	var normalized bool
 	switch data.(type) {
 	case []color.RGBA, []color.RGBA64, [][4]uint8, [][3]uint8, [][4]uint16, [][3]uint16:
@@ -174,7 +174,7 @@ func WriteImage(doc *gltf.Document, name string, mimeType string, r io.Reader) (
 // WriteAccessor adds a new Accessor to doc
 // and fills the buffer with the data.
 // Returns the index of the new accessor.
-func WriteAccessor(doc *gltf.Document, target gltf.Target, data interface{}) uint32 {
+func WriteAccessor(doc *gltf.Document, target gltf.Target, data any) uint32 {
 	ensurePadding(doc)
 	index := WriteBufferView(doc, target, data)
 	c, a, l := binary.Type(data)
@@ -194,7 +194,7 @@ func WriteAccessor(doc *gltf.Document, target gltf.Target, data interface{}) uin
 // Returns an slice with the indices of the newly created accessors,
 // with the same order as data or an error if the data elements
 // don´t have all the same length.
-func WriteAccessorsInterleaved(doc *gltf.Document, data ...interface{}) ([]uint32, error) {
+func WriteAccessorsInterleaved(doc *gltf.Document, data ...any) ([]uint32, error) {
 	ensurePadding(doc)
 	index, err := WriteBufferViewInterleaved(doc, data...)
 	if err != nil {
@@ -220,7 +220,7 @@ func WriteAccessorsInterleaved(doc *gltf.Document, data ...interface{}) ([]uint3
 // CustomAttribute defines an application-specific attribute
 type CustomAttribute struct {
 	Name string
-	Data interface{}
+	Data any
 }
 
 // Attributes defines all the vertex attributes that can
@@ -230,13 +230,13 @@ type Attributes struct {
 	Normal   [][3]float32
 	Tangent  [][4]float32
 	// [][2]uint8, [][2]uint16 or [][2]float32
-	TextureCoord_0, TextureCoord_1 interface{}
+	TextureCoord_0, TextureCoord_1 any
 	// [][4]uint8, [][4]uint16 or [][4]float32
-	Weights interface{}
+	Weights any
 	// [][4]uint8 or [][4]uint16
-	Joints interface{}
+	Joints any
 	//[]color.RGBA, []color.RGBA64, [][4]uint8, [][3]uint8, [][4]uint16, [][3]uint16, [][3]float32 or [][4]float32
-	Color            interface{}
+	Color            any
 	CustomAttributes []CustomAttribute
 }
 
@@ -251,7 +251,7 @@ func WriteAttributesInterleaved(doc *gltf.Document, v Attributes) (map[string]ui
 	}
 	var (
 		props []attrProps
-		data  []interface{}
+		data  []any
 	)
 	if len(v.Position) != 0 {
 		props = append(props, attrProps{Name: gltf.POSITION})
@@ -319,19 +319,19 @@ func WriteAttributesInterleaved(doc *gltf.Document, v Attributes) (map[string]ui
 // If success it returns the index of the new buffer view.
 // Returns the index of the new buffer view or an error if the data elements
 // don´t have all the same length.
-func WriteBufferViewInterleaved(doc *gltf.Document, data ...interface{}) (uint32, error) {
+func WriteBufferViewInterleaved(doc *gltf.Document, data ...any) (uint32, error) {
 	return writeBufferViews(doc, gltf.TargetArrayBuffer, data...)
 }
 
 // WriteBufferView adds a new BufferView to doc
 // and fills the buffer with the data.
 // Returns the index of the new buffer view.
-func WriteBufferView(doc *gltf.Document, target gltf.Target, data interface{}) uint32 {
+func WriteBufferView(doc *gltf.Document, target gltf.Target, data any) uint32 {
 	index, _ := writeBufferViews(doc, target, data)
 	return index
 }
 
-func writeBufferViews(doc *gltf.Document, target gltf.Target, data ...interface{}) (uint32, error) {
+func writeBufferViews(doc *gltf.Document, target gltf.Target, data ...any) (uint32, error) {
 	var refLength, stride, size uint32
 	for i, d := range data {
 		c, a, l := binary.Type(d)
@@ -392,7 +392,7 @@ func getPadding(offset uint32) uint32 {
 	return 4 - padAlign
 }
 
-func sliceLength(data interface{}) int {
+func sliceLength(data any) int {
 	if data == nil {
 		return 0
 	}

--- a/modeler/write_test.go
+++ b/modeler/write_test.go
@@ -333,7 +333,7 @@ func TestWritePosition(t *testing.T) {
 
 func TestWriteJoints(t *testing.T) {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string
@@ -390,7 +390,7 @@ func TestWriteJoints(t *testing.T) {
 
 func TestWriteWeights(t *testing.T) {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string
@@ -462,7 +462,7 @@ func TestWriteWeights(t *testing.T) {
 
 func TestWriteTextureCoord(t *testing.T) {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string
@@ -534,7 +534,7 @@ func TestWriteTextureCoord(t *testing.T) {
 
 func TestWriteIndices(t *testing.T) {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string
@@ -591,7 +591,7 @@ func TestWriteIndices(t *testing.T) {
 
 func TestWriteColor(t *testing.T) {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Using `any` instead of `interface{}` makes the code cleaner.

Command: `gofmt -w -r "interface{} -> any" .`