### PR TITLE
Simplify interleaved primitive attribute writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ gltf.Save(doc, "./test.gltf")
 
 ### Data interleaving
 
-The data of the attributes that are stored in a single bufferView may be stored as an Array-Of-Structures, which may produce a rendering perfomance boost in static attributes. `qmuntal/gltf/modeler` facilitates the creation of interleaved accessors and buffer views with the methods [WriteAttributesInterleaved](https://pkg.go.dev/github.com/qmuntal/gltf/modeler#WriteAttributesInterleaved), [WriteAccessorsInterleaved](https://pkg.go.dev/github.com/qmuntal/gltf/modeler#WriteAccessorsInterleaved), and [WriteBufferViewInterleaved](https://pkg.go.dev/github.com/qmuntal/gltf/modeler#WriteBufferViewInterleaved) being the first one the most recommended for creating mesh primitives:
+The data of the attributes that are stored in a single bufferView may be stored as an Array-Of-Structures, which may produce a rendering perfomance boost in static attributes. `qmuntal/gltf/modeler` facilitates the creation of interleaved accessors and buffer views with the methods [WritePrimitiveAttributes](https://pkg.go.dev/github.com/qmuntal/gltf/modeler#WritePrimitiveAttributes), [WriteAccessorsInterleaved](https://pkg.go.dev/github.com/qmuntal/gltf/modeler#WriteAccessorsInterleaved), and [WriteBufferViewInterleaved](https://pkg.go.dev/github.com/qmuntal/gltf/modeler#WriteBufferViewInterleaved) being the first one the most recommended for creating mesh primitives:
 
 ```go
 doc := gltf.NewDocument()
-attrs, _ := modeler.WriteAttributesInterleaved(doc,
+attrs, _ := modeler.WritePrimitiveAttributes(doc,
     modeler.PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{0, 0, 0}, {0, 10, 0}, {0, 0, 10}}},
     modeler.PrimitiveAttribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 0, 0}, {0, 255, 0}, {0, 0, 255}}},
 )

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ The data of the attributes that are stored in a single bufferView may be stored 
 
 ```go
 doc := gltf.NewDocument()
-attrs, _ := modeler.WriteAttributesInterleaved(doc, modeler.Attributes{
-  Position:       [][3]float32{{0, 0, 0}, {0, 10, 0}, {0, 0, 10}},
-  Color:          [][3]uint8{{255, 0, 0}, {0, 255, 0}, {0, 0, 255}},
-})
+attrs, _ := modeler.WriteAttributesInterleaved(doc,
+    modeler.Attribute{Name: gltf.POSITION, Data: [][3]float32{{0, 0, 0}, {0, 10, 0}, {0, 0, 10}}},
+    modeler.Attribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 0, 0}, {0, 255, 0}, {0, 0, 255}}},
+)
 doc.Meshes = []*gltf.Mesh{{
     Name: "Pyramid",
     Primitives: []*gltf.Primitive{{

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ doc.Meshes = []*gltf.Mesh{{
     Name: "Pyramid",
     Primitives: []*gltf.Primitive{{
         Indices: gltf.Index(modeler.WriteIndices(doc, []uint16{0, 1, 2})),
-        Attributes: map[string]uint32{
+        Attributes: gltf.PrimitiveAttributes{
           gltf.POSITION: modeler.WritePosition(doc, [][3]float32{{0, 0, 0}, {0, 10, 0}, {0, 0, 10}}),
           gltf.COLOR_0:  modeler.WriteColor(doc, [][3]uint8{{255, 0, 0}, {0, 255, 0}, {0, 0, 255}}),
         },
@@ -199,7 +199,7 @@ const ExtensionName = "FAKE_Extension"
 
 type Foo struct {
     BufferView uint32          `json:"bufferView"`
-    Attributes gltf.Attribute  `json:"attributes"`
+    Attributes gltf.Attributes  `json:"attributes"`
 }
 
 func init() {

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ The data of the attributes that are stored in a single bufferView may be stored 
 ```go
 doc := gltf.NewDocument()
 attrs, _ := modeler.WriteAttributesInterleaved(doc,
-    modeler.Attribute{Name: gltf.POSITION, Data: [][3]float32{{0, 0, 0}, {0, 10, 0}, {0, 0, 10}}},
-    modeler.Attribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 0, 0}, {0, 255, 0}, {0, 0, 255}}},
+    modeler.PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{0, 0, 0}, {0, 10, 0}, {0, 0, 10}}},
+    modeler.PrimitiveAttribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 0, 0}, {0, 255, 0}, {0, 0, 255}}},
 )
 doc.Meshes = []*gltf.Mesh{{
     Name: "Pyramid",

--- a/const.go
+++ b/const.go
@@ -160,8 +160,8 @@ const (
 	TargetElementArrayBuffer Target = 34963 // ELEMENT_ARRAY_BUFFER
 )
 
-// Attribute is a map that each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
-type Attribute = map[string]uint32
+// PrimitiveAttributes is a map that each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+type PrimitiveAttributes = map[string]uint32
 
 // PrimitiveMode defines the type of primitives to render. All valid values correspond to WebGL enums.
 type PrimitiveMode uint8

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -46,7 +46,7 @@ func TestOpen(t *testing.T) {
 			Buffers:   []*Buffer{{ByteLength: 1800, URI: "Cube.bin", Data: readFile("testdata/Cube/glTF/Cube.bin")}},
 			Images:    []*Image{{URI: "Cube_BaseColor.png"}, {URI: "Cube_MetallicRoughness.png"}},
 			Materials: []*Material{{Name: "Cube", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), PBRMetallicRoughness: &PBRMetallicRoughness{BaseColorFactor: &[4]float64{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorTexture: &TextureInfo{Index: 0}, MetallicRoughnessTexture: &TextureInfo{Index: 1}}}},
-			Meshes:    []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(0), Material: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{NORMAL: 2, POSITION: 1, TANGENT: 3, TEXCOORD_0: 4}}}}},
+			Meshes:    []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(0), Material: Index(0), Mode: PrimitiveTriangles, Attributes: PrimitiveAttributes{NORMAL: 2, POSITION: 1, TANGENT: 3, TEXCOORD_0: 4}}}}},
 			Nodes:     []*Node{{Mesh: Index(0), Name: "Cube", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}}},
 			Samplers:  []*Sampler{{WrapS: WrapRepeat, WrapT: WrapRepeat}},
 			Scene:     Index(0),
@@ -70,7 +70,7 @@ func TestOpen(t *testing.T) {
 				{Perspective: &Perspective{AspectRatio: Float(1.0), Yfov: 0.7, Zfar: Float(100), Znear: 0.01}},
 				{Orthographic: &Orthographic{Xmag: 1.0, Ymag: 1.0, Zfar: 100, Znear: 0.01}},
 			},
-			Meshes: []*Mesh{{Primitives: []*Primitive{{Indices: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{POSITION: 1}}}}},
+			Meshes: []*Mesh{{Primitives: []*Primitive{{Indices: Index(0), Mode: PrimitiveTriangles, Attributes: PrimitiveAttributes{POSITION: 1}}}}},
 			Nodes: []*Node{
 				{Mesh: Index(0), Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{-0.3, 0, 0, 0.9}, Scale: [3]float64{1, 1, 1}},
 				{Camera: Index(0), Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}, Translation: [3]float64{0.5, 0.5, 3.0}},
@@ -97,7 +97,7 @@ func TestOpen(t *testing.T) {
 			},
 			Buffers:   []*Buffer{{ByteLength: 1224, Data: readFile("testdata/BoxVertexColors/glTF-Binary/BoxVertexColors.glb")[1628+20+8:]}},
 			Materials: []*Material{{Name: "Default", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), PBRMetallicRoughness: &PBRMetallicRoughness{BaseColorFactor: &[4]float64{0.8, 0.8, 0.8, 1}, MetallicFactor: Float(0.1), RoughnessFactor: Float(0.99)}}},
-			Meshes:    []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(0), Material: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{POSITION: 1, COLOR_0: 3, NORMAL: 2, TEXCOORD_0: 4}}}}},
+			Meshes:    []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(0), Material: Index(0), Mode: PrimitiveTriangles, Attributes: PrimitiveAttributes{POSITION: 1, COLOR_0: 3, NORMAL: 2, TEXCOORD_0: 4}}}}},
 			Nodes: []*Node{
 				{Name: "RootNode", Children: []uint32{1, 2, 3}, Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
 				{Name: "Mesh", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
@@ -132,7 +132,7 @@ func TestOpen(t *testing.T) {
 				Name: "Material", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), NormalTexture: &NormalTexture{Index: Index(0), Scale: Float(1)}, PBRMetallicRoughness: &PBRMetallicRoughness{
 					BaseColorFactor: &[4]float64{1, 1, 1, 1}, MetallicFactor: Float(1), RoughnessFactor: Float(1), BaseColorTexture: &TextureInfo{Index: 1}, MetallicRoughnessTexture: &TextureInfo{Index: 2},
 				}}},
-			Meshes:   []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(3), Material: Index(0), Mode: PrimitiveTriangles, Attributes: map[string]uint32{NORMAL: 1, POSITION: 0, TEXCOORD_0: 2}}}}},
+			Meshes:   []*Mesh{{Name: "Cube", Primitives: []*Primitive{{Indices: Index(3), Material: Index(0), Mode: PrimitiveTriangles, Attributes: PrimitiveAttributes{NORMAL: 1, POSITION: 0, TEXCOORD_0: 2}}}}},
 			Nodes:    []*Node{{Mesh: Index(0), Name: "Cube", Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}}},
 			Scene:    Index(0),
 			Scenes:   []*Scene{{Name: "Scene", Nodes: []uint32{0}}},

--- a/encode_test.go
+++ b/encode_test.go
@@ -211,8 +211,8 @@ func TestEncoder_Encode(t *testing.T) {
 		{"withMeshes", args{&Document{Meshes: []*Mesh{
 			{Extras: 8.0, Name: "mesh_1", Weights: []float64{1.2, 2}},
 			{Extras: 8.0, Name: "mesh_2", Primitives: []*Primitive{
-				{Extras: 8.0, Attributes: Attribute{POSITION: 1}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
-				{Extras: 8.0, Targets: []Attribute{{POSITION: 1, "THEN": 4}, {"OTHER": 2}}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
+				{Extras: 8.0, Attributes: PrimitiveAttributes{POSITION: 1}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
+				{Extras: 8.0, Targets: []PrimitiveAttributes{{POSITION: 1, "THEN": 4}, {"OTHER": 2}}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
 			}},
 		}}}, false},
 		{"withNodes", args{&Document{Nodes: []*Node{

--- a/example_test.go
+++ b/example_test.go
@@ -36,7 +36,7 @@ func ExampleSave() {
 			Name: "Default", AlphaMode: gltf.AlphaOpaque, AlphaCutoff: gltf.Float(0.5),
 			PBRMetallicRoughness: &gltf.PBRMetallicRoughness{BaseColorFactor: &[4]float64{0.8, 0.8, 0.8, 1}, MetallicFactor: gltf.Float(0.1), RoughnessFactor: gltf.Float(0.99)},
 		}},
-		Meshes: []*gltf.Mesh{{Name: "Cube", Primitives: []*gltf.Primitive{{Indices: gltf.Index(0), Material: gltf.Index(0), Mode: gltf.PrimitiveTriangles, Attributes: map[string]uint32{gltf.POSITION: 1, gltf.COLOR_0: 3, gltf.NORMAL: 2, gltf.TEXCOORD_0: 4}}}}},
+		Meshes: []*gltf.Mesh{{Name: "Cube", Primitives: []*gltf.Primitive{{Indices: gltf.Index(0), Material: gltf.Index(0), Mode: gltf.PrimitiveTriangles, Attributes: gltf.PrimitiveAttributes{gltf.POSITION: 1, gltf.COLOR_0: 3, gltf.NORMAL: 2, gltf.TEXCOORD_0: 4}}}}},
 		Nodes: []*gltf.Node{
 			{Name: "RootNode", Children: []uint32{1, 2, 3}},
 			{Name: "Mesh"},

--- a/gltf.go
+++ b/gltf.go
@@ -260,13 +260,13 @@ type Mesh struct {
 
 // Primitive defines the geometry to be rendered with the given material.
 type Primitive struct {
-	Extensions Extensions    `json:"extensions,omitempty"`
-	Extras     any           `json:"extras,omitempty"`
-	Attributes Attribute     `json:"attributes"`
-	Indices    *uint32       `json:"indices,omitempty"` // The index of the accessor that contains the indices.
-	Material   *uint32       `json:"material,omitempty"`
-	Mode       PrimitiveMode `json:"mode,omitempty" validate:"lte=6"`
-	Targets    []Attribute   `json:"targets,omitempty" validate:"omitempty,dive,dive,keys,oneof=POSITION NORMAL TANGENT,endkeys"` // Only POSITION, NORMAL, and TANGENT supported.
+	Extensions Extensions            `json:"extensions,omitempty"`
+	Extras     any                   `json:"extras,omitempty"`
+	Attributes PrimitiveAttributes   `json:"attributes"`
+	Indices    *uint32               `json:"indices,omitempty"` // The index of the accessor that contains the indices.
+	Material   *uint32               `json:"material,omitempty"`
+	Mode       PrimitiveMode         `json:"mode,omitempty" validate:"lte=6"`
+	Targets    []PrimitiveAttributes `json:"targets,omitempty" validate:"omitempty,dive,dive,keys,oneof=POSITION NORMAL TANGENT,endkeys"` // Only POSITION, NORMAL, and TANGENT supported.
 }
 
 // The Material appearance of a primitive.

--- a/modeler/example_test.go
+++ b/modeler/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 		Primitives: []*gltf.Primitive{
 			{
 				Indices: gltf.Index(indicesAccessor),
-				Attributes: map[string]uint32{
+				Attributes: gltf.PrimitiveAttributes{
 					gltf.POSITION: positionAccessor,
 					gltf.COLOR_0:  colorIndices,
 				},
@@ -60,7 +60,7 @@ func ExampleWriteImage() {
 		Primitives: []*gltf.Primitive{
 			{
 				Indices: gltf.Index(indicesAccessor),
-				Attributes: map[string]uint32{
+				Attributes: gltf.PrimitiveAttributes{
 					gltf.POSITION:   positionAccessor,
 					gltf.TEXCOORD_0: textureAccessor,
 				},
@@ -87,7 +87,7 @@ func ExampleWriteAccessorsInterleaved() {
 		Primitives: []*gltf.Primitive{
 			{
 				Indices: gltf.Index(indicesAccessor),
-				Attributes: map[string]uint32{
+				Attributes: gltf.PrimitiveAttributes{
 					gltf.POSITION: indices[0],
 					gltf.COLOR_0:  indices[1],
 				},

--- a/modeler/example_test.go
+++ b/modeler/example_test.go
@@ -104,16 +104,16 @@ func ExampleWriteAccessorsInterleaved() {
 func ExampleWriteAttributesInterleaved() {
 	doc := gltf.NewDocument()
 	attrs, _ := modeler.WriteAttributesInterleaved(doc,
-		modeler.Attribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
-		modeler.Attribute{Name: gltf.NORMAL, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
-		modeler.Attribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
-		modeler.Attribute{Name: gltf.TEXCOORD_0, Data: [][2]uint8{{0, 255}, {255, 0}}},
-		modeler.Attribute{Name: gltf.TEXCOORD_1, Data: [][2]float32{{1, 2}, {1, 2}}},
-		modeler.Attribute{Name: gltf.JOINTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
-		modeler.Attribute{Name: gltf.WEIGHTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
-		modeler.Attribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 255, 255}, {0, 255, 0}}},
-		modeler.Attribute{Name: "COLOR_1", Data: [][3]uint8{{0, 0, 255}, {100, 200, 0}}},
-		modeler.Attribute{Name: "COLOR_2", Data: [][4]uint8{{23, 58, 188, 1}, {0, 155, 0, 0}}},
+		modeler.PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		modeler.PrimitiveAttribute{Name: gltf.NORMAL, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		modeler.PrimitiveAttribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		modeler.PrimitiveAttribute{Name: gltf.TEXCOORD_0, Data: [][2]uint8{{0, 255}, {255, 0}}},
+		modeler.PrimitiveAttribute{Name: gltf.TEXCOORD_1, Data: [][2]float32{{1, 2}, {1, 2}}},
+		modeler.PrimitiveAttribute{Name: gltf.JOINTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		modeler.PrimitiveAttribute{Name: gltf.WEIGHTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		modeler.PrimitiveAttribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 255, 255}, {0, 255, 0}}},
+		modeler.PrimitiveAttribute{Name: "COLOR_1", Data: [][3]uint8{{0, 0, 255}, {100, 200, 0}}},
+		modeler.PrimitiveAttribute{Name: "COLOR_2", Data: [][4]uint8{{23, 58, 188, 1}, {0, 155, 0, 0}}},
 	)
 	indicesAccessor := modeler.WriteIndices(doc, []uint16{0, 1, 2, 3, 1, 0, 0, 2, 3, 1, 4, 2, 4, 3, 2, 4, 1, 3})
 	doc.Meshes = []*gltf.Mesh{{

--- a/modeler/example_test.go
+++ b/modeler/example_test.go
@@ -103,7 +103,7 @@ func ExampleWriteAccessorsInterleaved() {
 
 func ExampleWriteAttributesInterleaved() {
 	doc := gltf.NewDocument()
-	attrs, _ := modeler.WriteAttributesInterleaved(doc,
+	attrs, _ := modeler.WritePrimitiveAttributes(doc,
 		modeler.PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
 		modeler.PrimitiveAttribute{Name: gltf.NORMAL, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
 		modeler.PrimitiveAttribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},

--- a/modeler/example_test.go
+++ b/modeler/example_test.go
@@ -103,20 +103,18 @@ func ExampleWriteAccessorsInterleaved() {
 
 func ExampleWriteAttributesInterleaved() {
 	doc := gltf.NewDocument()
-	attrs, _ := modeler.WriteAttributesInterleaved(doc, modeler.Attributes{
-		Position:       [][3]float32{{1, 2, 3}, {0, 0, -1}},
-		Normal:         [][3]float32{{1, 2, 3}, {0, 0, -1}},
-		Tangent:        [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		TextureCoord_0: [][2]uint8{{0, 255}, {255, 0}},
-		TextureCoord_1: [][2]float32{{1, 2}, {1, 2}},
-		Joints:         [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		Weights:        [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		Color:          [][3]uint8{{255, 255, 255}, {0, 255, 0}},
-		CustomAttributes: []modeler.CustomAttribute{
-			{Name: "COLOR_1", Data: [][3]uint8{{0, 0, 255}, {100, 200, 0}}},
-			{Name: "COLOR_2", Data: [][4]uint8{{23, 58, 188, 1}, {0, 155, 0, 0}}},
-		},
-	})
+	attrs, _ := modeler.WriteAttributesInterleaved(doc,
+		modeler.Attribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		modeler.Attribute{Name: gltf.NORMAL, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		modeler.Attribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		modeler.Attribute{Name: gltf.TEXCOORD_0, Data: [][2]uint8{{0, 255}, {255, 0}}},
+		modeler.Attribute{Name: gltf.TEXCOORD_1, Data: [][2]float32{{1, 2}, {1, 2}}},
+		modeler.Attribute{Name: gltf.JOINTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		modeler.Attribute{Name: gltf.WEIGHTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		modeler.Attribute{Name: gltf.COLOR_0, Data: [][3]uint8{{255, 255, 255}, {0, 255, 0}}},
+		modeler.Attribute{Name: "COLOR_1", Data: [][3]uint8{{0, 0, 255}, {100, 200, 0}}},
+		modeler.Attribute{Name: "COLOR_2", Data: [][4]uint8{{23, 58, 188, 1}, {0, 155, 0, 0}}},
+	)
 	indicesAccessor := modeler.WriteIndices(doc, []uint16{0, 1, 2, 3, 1, 0, 0, 2, 3, 1, 4, 2, 4, 3, 2, 4, 1, 3})
 	doc.Meshes = []*gltf.Mesh{{
 		Name: "Pyramid",

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -222,9 +222,9 @@ type PrimitiveAttribute struct {
 	Data any
 }
 
-// WriteAttributesInterleaved write all the attributes to doc.
+// WritePrimitiveAttributes write all the primitives attributes to doc as interleaved data.
 // Returns an attribute map that can be directly used as a primitive attributes.
-func WriteAttributesInterleaved(doc *gltf.Document, attr ...PrimitiveAttribute) (gltf.PrimitiveAttributes, error) {
+func WritePrimitiveAttributes(doc *gltf.Document, attr ...PrimitiveAttribute) (gltf.PrimitiveAttributes, error) {
 	type attrProps struct {
 		Name       string
 		Normalized bool
@@ -256,7 +256,7 @@ func WriteAttributesInterleaved(doc *gltf.Document, attr ...PrimitiveAttribute) 
 	if err != nil {
 		return nil, err
 	}
-	attrs := make(map[string]uint32, len(props))
+	attrs := make(gltf.PrimitiveAttributes, len(props))
 	for i, index := range indices {
 		prop := props[i]
 		attrs[prop.Name] = index

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -216,7 +216,7 @@ func WriteAccessorsInterleaved(doc *gltf.Document, data ...any) ([]uint32, error
 	return indices, nil
 }
 
-// Attribute is a property of a gltf object.
+// Attribute holds the data referenced by a gltf.Attribute.
 type Attribute struct {
 	Name string
 	Data any
@@ -224,7 +224,7 @@ type Attribute struct {
 
 // WriteAttributesInterleaved write all the attributes to doc.
 // Returns an attribute map that can be directly used as a primitive attributes.
-func WriteAttributesInterleaved(doc *gltf.Document, attr ...Attribute) (map[string]uint32, error) {
+func WriteAttributesInterleaved(doc *gltf.Document, attr ...Attribute) (gltf.PrimitiveAttributes, error) {
 	type attrProps struct {
 		Name       string
 		Normalized bool

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -216,15 +216,15 @@ func WriteAccessorsInterleaved(doc *gltf.Document, data ...any) ([]uint32, error
 	return indices, nil
 }
 
-// Attribute holds the data referenced by a gltf.Attribute.
-type Attribute struct {
+// PrimitiveAttribute holds the data referenced by a gltf.PrimitiveAttributes entry.
+type PrimitiveAttribute struct {
 	Name string
 	Data any
 }
 
 // WriteAttributesInterleaved write all the attributes to doc.
 // Returns an attribute map that can be directly used as a primitive attributes.
-func WriteAttributesInterleaved(doc *gltf.Document, attr ...Attribute) (gltf.PrimitiveAttributes, error) {
+func WriteAttributesInterleaved(doc *gltf.Document, attr ...PrimitiveAttribute) (gltf.PrimitiveAttributes, error) {
 	type attrProps struct {
 		Name       string
 		Normalized bool

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -268,7 +268,7 @@ func WritePrimitiveAttributes(doc *gltf.Document, attr ...PrimitiveAttribute) (g
 			normalized, err = checkColor(a.Data)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", a.Name, a.Name)
+			return nil, fmt.Errorf("%s: %w", a.Name, err)
 		}
 		data = append(data, a.Data)
 		props = append(props, attrProps{Name: a.Name, Normalized: normalized})

--- a/modeler/write_test.go
+++ b/modeler/write_test.go
@@ -31,7 +31,7 @@ func TestAlignment(t *testing.T) {
 func TestWriteAttributesInterleaved(t *testing.T) {
 	data := [][3]float32{{1, 2, 3}, {0, 0, -1}}
 	doc := gltf.NewDocument()
-	attrs, err := WriteAttributesInterleaved(doc,
+	attrs, err := WritePrimitiveAttributes(doc,
 		PrimitiveAttribute{Name: gltf.POSITION, Data: data},
 		PrimitiveAttribute{Name: gltf.NORMAL, Data: data},
 		PrimitiveAttribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
@@ -89,7 +89,7 @@ func TestWriteAttributesInterleaved(t *testing.T) {
 
 func TestWriteAttributesInterleaved_OnlyPosition(t *testing.T) {
 	doc := gltf.NewDocument()
-	_, err := WriteAttributesInterleaved(doc,
+	_, err := WritePrimitiveAttributes(doc,
 		PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
 		PrimitiveAttribute{Name: gltf.TANGENT, Data: make([][4]float32, 0)},
 		PrimitiveAttribute{Name: "COLOR_1"})
@@ -103,7 +103,7 @@ func TestWriteAttributesInterleaved_OnlyPosition(t *testing.T) {
 
 func TestWriteAttributesInterleaved_Error(t *testing.T) {
 	doc := gltf.NewDocument()
-	_, err := WriteAttributesInterleaved(doc,
+	_, err := WritePrimitiveAttributes(doc,
 		PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
 		PrimitiveAttribute{Name: gltf.COLOR_0, Data: [][3]float32{{1, 2, 3}}},
 	)

--- a/modeler/write_test.go
+++ b/modeler/write_test.go
@@ -31,20 +31,18 @@ func TestAlignment(t *testing.T) {
 func TestWriteAttributesInterleaved(t *testing.T) {
 	data := [][3]float32{{1, 2, 3}, {0, 0, -1}}
 	doc := gltf.NewDocument()
-	attrs, err := WriteAttributesInterleaved(doc, Attributes{
-		Position:       data,
-		Normal:         data,
-		Tangent:        [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		TextureCoord_0: [][2]float32{{1, 2}, {1, 2}},
-		TextureCoord_1: [][2]float32{{1, 2}, {1, 2}},
-		Joints:         [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		Weights:        [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		Color:          data,
-		CustomAttributes: []CustomAttribute{
-			{Name: "COLOR_1", Data: data},
-			{Name: "COLOR_2", Data: data},
-		},
-	})
+	attrs, err := WriteAttributesInterleaved(doc,
+		Attribute{Name: gltf.POSITION, Data: data},
+		Attribute{Name: gltf.NORMAL, Data: data},
+		Attribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		Attribute{Name: gltf.TEXCOORD_0, Data: [][2]float32{{1, 2}, {1, 2}}},
+		Attribute{Name: gltf.TEXCOORD_1, Data: [][2]float32{{1, 2}, {1, 2}}},
+		Attribute{Name: gltf.WEIGHTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		Attribute{Name: gltf.JOINTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		Attribute{Name: gltf.COLOR_0, Data: data},
+		Attribute{Name: "COLOR_1", Data: data},
+		Attribute{Name: "COLOR_2", Data: data},
+	)
 	if err != nil {
 		t.Fatalf("TestWriteAttributesInterleaved() got error = %v", err)
 	}
@@ -91,11 +89,10 @@ func TestWriteAttributesInterleaved(t *testing.T) {
 
 func TestWriteAttributesInterleaved_OnlyPosition(t *testing.T) {
 	doc := gltf.NewDocument()
-	_, err := WriteAttributesInterleaved(doc, Attributes{
-		Position:         [][3]float32{{1, 2, 3}, {0, 0, -1}},
-		Tangent:          make([][4]float32, 0),
-		CustomAttributes: []CustomAttribute{{Name: "COLOR_1"}},
-	})
+	_, err := WriteAttributesInterleaved(doc,
+		Attribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		Attribute{Name: gltf.TANGENT, Data: make([][4]float32, 0)},
+		Attribute{Name: "COLOR_1"})
 	if err != nil {
 		t.Fatalf("TestWriteAttributesInterleaved_OnlyPosition() got error = %v", err)
 	}
@@ -106,10 +103,10 @@ func TestWriteAttributesInterleaved_OnlyPosition(t *testing.T) {
 
 func TestWriteAttributesInterleaved_Error(t *testing.T) {
 	doc := gltf.NewDocument()
-	_, err := WriteAttributesInterleaved(doc, Attributes{
-		Position: [][3]float32{{1, 2, 3}, {0, 0, -1}},
-		Color:    [][3]float32{{1, 2, 3}},
-	})
+	_, err := WriteAttributesInterleaved(doc,
+		Attribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		Attribute{Name: gltf.COLOR_0, Data: [][3]float32{{1, 2, 3}}},
+	)
 	if err == nil {
 		t.Error("TestWriteAttributesInterleaved_Error() expected an error")
 	}

--- a/modeler/write_test.go
+++ b/modeler/write_test.go
@@ -32,16 +32,16 @@ func TestWriteAttributesInterleaved(t *testing.T) {
 	data := [][3]float32{{1, 2, 3}, {0, 0, -1}}
 	doc := gltf.NewDocument()
 	attrs, err := WriteAttributesInterleaved(doc,
-		Attribute{Name: gltf.POSITION, Data: data},
-		Attribute{Name: gltf.NORMAL, Data: data},
-		Attribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
-		Attribute{Name: gltf.TEXCOORD_0, Data: [][2]float32{{1, 2}, {1, 2}}},
-		Attribute{Name: gltf.TEXCOORD_1, Data: [][2]float32{{1, 2}, {1, 2}}},
-		Attribute{Name: gltf.WEIGHTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
-		Attribute{Name: gltf.JOINTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
-		Attribute{Name: gltf.COLOR_0, Data: data},
-		Attribute{Name: "COLOR_1", Data: data},
-		Attribute{Name: "COLOR_2", Data: data},
+		PrimitiveAttribute{Name: gltf.POSITION, Data: data},
+		PrimitiveAttribute{Name: gltf.NORMAL, Data: data},
+		PrimitiveAttribute{Name: gltf.TANGENT, Data: [][4]float32{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		PrimitiveAttribute{Name: gltf.TEXCOORD_0, Data: [][2]float32{{1, 2}, {1, 2}}},
+		PrimitiveAttribute{Name: gltf.TEXCOORD_1, Data: [][2]float32{{1, 2}, {1, 2}}},
+		PrimitiveAttribute{Name: gltf.WEIGHTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		PrimitiveAttribute{Name: gltf.JOINTS_0, Data: [][4]uint8{{1, 2, 3, 4}, {1, 2, 3, 4}}},
+		PrimitiveAttribute{Name: gltf.COLOR_0, Data: data},
+		PrimitiveAttribute{Name: "COLOR_1", Data: data},
+		PrimitiveAttribute{Name: "COLOR_2", Data: data},
 	)
 	if err != nil {
 		t.Fatalf("TestWriteAttributesInterleaved() got error = %v", err)
@@ -90,9 +90,9 @@ func TestWriteAttributesInterleaved(t *testing.T) {
 func TestWriteAttributesInterleaved_OnlyPosition(t *testing.T) {
 	doc := gltf.NewDocument()
 	_, err := WriteAttributesInterleaved(doc,
-		Attribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
-		Attribute{Name: gltf.TANGENT, Data: make([][4]float32, 0)},
-		Attribute{Name: "COLOR_1"})
+		PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		PrimitiveAttribute{Name: gltf.TANGENT, Data: make([][4]float32, 0)},
+		PrimitiveAttribute{Name: "COLOR_1"})
 	if err != nil {
 		t.Fatalf("TestWriteAttributesInterleaved_OnlyPosition() got error = %v", err)
 	}
@@ -104,8 +104,8 @@ func TestWriteAttributesInterleaved_OnlyPosition(t *testing.T) {
 func TestWriteAttributesInterleaved_Error(t *testing.T) {
 	doc := gltf.NewDocument()
 	_, err := WriteAttributesInterleaved(doc,
-		Attribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
-		Attribute{Name: gltf.COLOR_0, Data: [][3]float32{{1, 2, 3}}},
+		PrimitiveAttribute{Name: gltf.POSITION, Data: [][3]float32{{1, 2, 3}, {0, 0, -1}}},
+		PrimitiveAttribute{Name: gltf.COLOR_0, Data: [][3]float32{{1, 2, 3}}},
 	)
 	if err == nil {
 		t.Error("TestWriteAttributesInterleaved_Error() expected an error")


### PR DESCRIPTION
Changes:
- Rename `modeler.Attribute` to `modeler.PrimitiveAttributes`
- Rename `gltf.Attribute` to `gltf.PrimitiveAttributes`
- Improve `modeler.WritePrimitiveAttributes` error handling
- Change `modeler.WritePrimitiveAttributes` parameters to accept a `modeler.PrimitiveAttributes` to the now defunc `modeler.Attributes`