### PR TITLE
Fix vertex color normalization across component types

### DIFF
--- a/math.go
+++ b/math.go
@@ -46,9 +46,9 @@ func DenormalizeUshort(v uint16) float32 {
 // to its uint8 represtation (from 0 to 255).
 func NormalizeRGB(v [3]float32) [3]uint8 {
 	return [3]uint8{
-		uint8(deliniarize(v[0]) * 255),
-		uint8(deliniarize(v[1]) * 255),
-		uint8(deliniarize(v[2]) * 255),
+		NormalizeUbyte(v[0]),
+		NormalizeUbyte(v[1]),
+		NormalizeUbyte(v[2]),
 	}
 }
 
@@ -56,9 +56,9 @@ func NormalizeRGB(v [3]float32) [3]uint8 {
 // to its float represtation (from 0 to 1).
 func DenormalizeRGB(v [3]uint8) [3]float32 {
 	return [3]float32{
-		linearize(float32(v[0]) / 255),
-		linearize(float32(v[1]) / 255),
-		linearize(float32(v[2]) / 255),
+		DenormalizeUbyte(v[0]),
+		DenormalizeUbyte(v[1]),
+		DenormalizeUbyte(v[2]),
 	}
 }
 
@@ -66,10 +66,10 @@ func DenormalizeRGB(v [3]uint8) [3]float32 {
 // to its uint8 represtation (from 0 to 255).
 func NormalizeRGBA(v [4]float32) [4]uint8 {
 	return [4]uint8{
-		uint8(deliniarize(v[0]) * 255),
-		uint8(deliniarize(v[1]) * 255),
-		uint8(deliniarize(v[2]) * 255),
-		uint8(v[3] * 255),
+		NormalizeUbyte(v[0]),
+		NormalizeUbyte(v[1]),
+		NormalizeUbyte(v[2]),
+		NormalizeUbyte(v[3]),
 	}
 }
 
@@ -77,10 +77,10 @@ func NormalizeRGBA(v [4]float32) [4]uint8 {
 // to its float represtation (from 0 to 1).
 func DenormalizeRGBA(v [4]uint8) [4]float32 {
 	return [4]float32{
-		linearize(float32(v[0]) / 255),
-		linearize(float32(v[1]) / 255),
-		linearize(float32(v[2]) / 255),
-		float32(v[3]) / 255,
+		DenormalizeUbyte(v[0]),
+		DenormalizeUbyte(v[1]),
+		DenormalizeUbyte(v[2]),
+		DenormalizeUbyte(v[3]),
 	}
 }
 
@@ -88,9 +88,9 @@ func DenormalizeRGBA(v [4]uint8) [4]float32 {
 // to its uint16 represtation (from 0 to 65535).
 func NormalizeRGB64(v [3]float32) [3]uint16 {
 	return [3]uint16{
-		uint16(deliniarize(v[0]) * 65535),
-		uint16(deliniarize(v[1]) * 65535),
-		uint16(deliniarize(v[2]) * 65535),
+		NormalizeUshort(v[0]),
+		NormalizeUshort(v[1]),
+		NormalizeUshort(v[2]),
 	}
 }
 
@@ -98,9 +98,9 @@ func NormalizeRGB64(v [3]float32) [3]uint16 {
 // to its float represtation (from 0 to 1).
 func DenormalizeRGB64(v [3]uint16) [3]float32 {
 	return [3]float32{
-		linearize(float32(v[0]) / 65535),
-		linearize(float32(v[1]) / 65535),
-		linearize(float32(v[2]) / 65535),
+		DenormalizeUshort(v[0]),
+		DenormalizeUshort(v[1]),
+		DenormalizeUshort(v[2]),
 	}
 }
 
@@ -108,10 +108,10 @@ func DenormalizeRGB64(v [3]uint16) [3]float32 {
 // to its uint16 represtation (from 0 to 65535).
 func NormalizeRGBA64(v [4]float32) [4]uint16 {
 	return [4]uint16{
-		uint16(deliniarize(v[0]) * 65535),
-		uint16(deliniarize(v[1]) * 65535),
-		uint16(deliniarize(v[2]) * 65535),
-		uint16(v[3] * 65535),
+		NormalizeUshort(v[0]),
+		NormalizeUshort(v[1]),
+		NormalizeUshort(v[2]),
+		NormalizeUshort(v[3]),
 	}
 }
 
@@ -119,23 +119,9 @@ func NormalizeRGBA64(v [4]float32) [4]uint16 {
 // to its float represtation (from 0 to 1).
 func DenormalizeRGBA64(v [4]uint16) [4]float32 {
 	return [4]float32{
-		linearize(float32(v[0]) / 65535),
-		linearize(float32(v[1]) / 65535),
-		linearize(float32(v[2]) / 65535),
-		float32(v[3]) / 65535,
+		DenormalizeUshort(v[0]),
+		DenormalizeUshort(v[1]),
+		DenormalizeUshort(v[2]),
+		DenormalizeUshort(v[3]),
 	}
-}
-
-func linearize(v float32) float32 {
-	if v <= 0.04045 {
-		return float32(v / 12.92)
-	}
-	return float32(math.Pow(float64(v+0.055)/1.055, 2.4))
-}
-
-func deliniarize(v float32) float32 {
-	if v < 0.0031308 {
-		return v * 12.92
-	}
-	return float32(1.055*math.Pow(float64(v), 1.0/2.4) - 0.055)
 }

--- a/math_test.go
+++ b/math_test.go
@@ -49,9 +49,9 @@ func TestNormalizeRGBA(t *testing.T) {
 		want [4]uint8
 	}{
 		{"empty", args{[4]float32{}}, [4]uint8{}},
-		{"base", args{[4]float32{0.0003035, 0.0003035, 0.0003035, 0.00392156}}, [4]uint8{0, 0, 0, 0}},
+		{"base", args{[4]float32{1.0 / 255, 1.0 / 255, 1.0 / 255, 1.0 / 255}}, [4]uint8{1, 1, 1, 1}},
 		{"max", args{[4]float32{1, 1, 1, 1}}, [4]uint8{255, 255, 255, 255}},
-		{"other", args{[4]float32{0.045186, 0.1878207, 0.4564110, 0.86274509}}, [4]uint8{59, 119, 179, 220}},
+		{"other", args{[4]float32{60.0 / 255, 120.0 / 255, 180.0 / 255, 220.0 / 255}}, [4]uint8{60, 120, 180, 220}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,9 +74,9 @@ func TestNormalizeRGB(t *testing.T) {
 		want [3]uint8
 	}{
 		{"empty", args{[3]float32{}}, [3]uint8{}},
-		{"base", args{[3]float32{0.0003035, 0.0003035, 0.0003035}}, [3]uint8{0, 0, 0}},
+		{"base", args{[3]float32{1.0 / 255, 1.0 / 255, 1.0 / 255}}, [3]uint8{1, 1, 1}},
 		{"max", args{[3]float32{1, 1, 1}}, [3]uint8{255, 255, 255}},
-		{"other", args{[3]float32{0.045186, 0.1878207, 0.4564110}}, [3]uint8{59, 119, 179}},
+		{"other", args{[3]float32{60.0 / 255, 120.0 / 255, 180.0 / 255}}, [3]uint8{60, 120, 180}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -99,9 +99,9 @@ func TestNormalizeRGBA64(t *testing.T) {
 		want [4]uint16
 	}{
 		{"empty", args{[4]float32{}}, [4]uint16{}},
-		{"base", args{[4]float32{0.001181, 0.001181, 0.001181, 0.0152590}}, [4]uint16{999, 999, 999, 999}},
+		{"base", args{[4]float32{1000.0 / 65535, 1000.0 / 65535, 1000.0 / 65535, 1000.0 / 65535}}, [4]uint16{1000, 1000, 1000, 1000}},
 		{"max", args{[4]float32{1, 1, 1, 1}}, [4]uint16{65535, 65535, 65535, 65535}},
-		{"other", args{[4]float32{0.0087617, 0.0280836, 0.061314, 0.335698}}, [4]uint16{5999, 11999, 17999, 21999}},
+		{"other", args{[4]float32{6000.0 / 65535, 12000.0 / 65535, 18000.0 / 65535, 22000.0 / 65535}}, [4]uint16{6000, 12000, 18000, 22000}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -124,9 +124,9 @@ func TestNormalizeRGB64(t *testing.T) {
 		want [3]uint16
 	}{
 		{"empty", args{[3]float32{}}, [3]uint16{}},
-		{"base", args{[3]float32{0.001181, 0.001181, 0.001181}}, [3]uint16{999, 999, 999}},
+		{"base", args{[3]float32{1000.0 / 65535, 1000.0 / 65535, 1000.0 / 65535}}, [3]uint16{1000, 1000, 1000}},
 		{"max", args{[3]float32{1, 1, 1}}, [3]uint16{65535, 65535, 65535}},
-		{"other", args{[3]float32{0.0087617, 0.0280836, 0.061314}}, [3]uint16{5999, 11999, 17999}},
+		{"other", args{[3]float32{6000.0 / 65535, 12000.0 / 65535, 18000.0 / 65535}}, [3]uint16{6000, 12000, 18000}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -149,9 +149,9 @@ func TestDenormalizeRGBA(t *testing.T) {
 		want [4]float32
 	}{
 		{"empty", args{[4]uint8{}}, [4]float32{}},
-		{"base", args{[4]uint8{1, 1, 1, 1}}, [4]float32{0.0003035, 0.0003035, 0.0003035, 0.00392156}},
+		{"base", args{[4]uint8{1, 1, 1, 1}}, [4]float32{1.0 / 255, 1.0 / 255, 1.0 / 255, 1.0 / 255}},
 		{"max", args{[4]uint8{255, 255, 255, 255}}, [4]float32{1, 1, 1, 1}},
-		{"other", args{[4]uint8{60, 120, 180, 220}}, [4]float32{0.045186, 0.1878207, 0.4564110, 0.86274509}},
+		{"other", args{[4]uint8{60, 120, 180, 220}}, [4]float32{60.0 / 255, 120.0 / 255, 180.0 / 255, 220.0 / 255}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -174,9 +174,9 @@ func TestDenormalizeRGB(t *testing.T) {
 		want [3]float32
 	}{
 		{"empty", args{[3]uint8{}}, [3]float32{}},
-		{"base", args{[3]uint8{1, 1, 1}}, [3]float32{0.0003035, 0.0003035, 0.0003035}},
+		{"base", args{[3]uint8{1, 1, 1}}, [3]float32{1.0 / 255, 1.0 / 255, 1.0 / 255}},
 		{"max", args{[3]uint8{255, 255, 255}}, [3]float32{1, 1, 1}},
-		{"other", args{[3]uint8{60, 120, 180}}, [3]float32{0.045186, 0.1878207, 0.4564110}},
+		{"other", args{[3]uint8{60, 120, 180}}, [3]float32{60.0 / 255, 120.0 / 255, 180.0 / 255}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -199,9 +199,9 @@ func TestDenormalizeRGBA64(t *testing.T) {
 		want [4]float32
 	}{
 		{"empty", args{[4]uint16{}}, [4]float32{}},
-		{"base", args{[4]uint16{1000, 1000, 1000, 1000}}, [4]float32{0.001181, 0.001181, 0.001181, 0.0152590}},
+		{"base", args{[4]uint16{1000, 1000, 1000, 1000}}, [4]float32{1000.0 / 65535, 1000.0 / 65535, 1000.0 / 65535, 1000.0 / 65535}},
 		{"max", args{[4]uint16{65535, 65535, 65535, 65535}}, [4]float32{1, 1, 1, 1}},
-		{"other", args{[4]uint16{6000, 12000, 18000, 22000}}, [4]float32{0.0087617, 0.0280836, 0.061314, 0.335698}},
+		{"other", args{[4]uint16{6000, 12000, 18000, 22000}}, [4]float32{6000.0 / 65535, 12000.0 / 65535, 18000.0 / 65535, 22000.0 / 65535}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -224,9 +224,9 @@ func TestDenormalizeRGB64(t *testing.T) {
 		want [3]float32
 	}{
 		{"empty", args{[3]uint16{}}, [3]float32{}},
-		{"base", args{[3]uint16{1000, 1000, 1000}}, [3]float32{0.001181, 0.001181, 0.001181}},
+		{"base", args{[3]uint16{1000, 1000, 1000}}, [3]float32{1000.0 / 65535, 1000.0 / 65535, 1000.0 / 65535}},
 		{"max", args{[3]uint16{65535, 65535, 65535}}, [3]float32{1, 1, 1}},
-		{"other", args{[3]uint16{6000, 12000, 18000}}, [3]float32{0.0087617, 0.0280836, 0.061314}},
+		{"other", args{[3]uint16{6000, 12000, 18000}}, [3]float32{6000.0 / 65535, 12000.0 / 65535, 18000.0 / 65535}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modeler/read_test.go
+++ b/modeler/read_test.go
@@ -1,12 +1,22 @@
 package modeler_test
 
 import (
+	"encoding/binary"
+	"math"
 	"reflect"
 	"testing"
 
 	"github.com/qmuntal/gltf"
 	"github.com/qmuntal/gltf/modeler"
 )
+
+func float32Bytes(values ...float32) []byte {
+	data := make([]byte, 4*len(values))
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(data[i*4:], math.Float32bits(value))
+	}
+	return data
+}
 
 func TestReadColor64_ReuseBuffer(t *testing.T) {
 	data := []byte{1, 2, 3, 4, 1, 2, 3, 4}
@@ -602,9 +612,12 @@ func TestReadColor(t *testing.T) {
 		{"[4]uint16-normalized", args{[]byte{0, 1, 115, 33, 200, 0, 255, 255}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]uint8{{1, 33, 1, 255}}, false},
-		{"[4]float32", args{[]byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64}, &gltf.Accessor{
+		{"[4]uint16-normalized-linear", args{[]byte{37, 3, 180, 50, 255, 255, 255, 255}, &gltf.Accessor{
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
+		}, nil}, [][4]uint8{{3, 51, 255, 255}}, false},
+		{"[4]float32", args{float32Bytes(0, 0.5, 1, 1), &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentFloat,
-		}, nil}, [][4]uint8{{255, 89, 155, 252}}, false},
+		}, nil}, [][4]uint8{{0, 128, 255, 255}}, false},
 		{"[3]uint8", args{[]byte{1, 2, 3, 0}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUbyte,
 		}, nil}, [][4]uint8{{1, 2, 3, 255}}, false},
@@ -614,9 +627,9 @@ func TestReadColor(t *testing.T) {
 		{"[3]uint16-normalized", args{[]byte{0, 1, 255, 0, 255, 0, 0, 0}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]uint8{{1, 1, 1, 255}}, false},
-		{"[3]float32", args{[]byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64}, &gltf.Accessor{
+		{"[3]float32", args{float32Bytes(805.0/65535.0, 12980.0/65535.0, 1), &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentFloat,
-		}, nil}, [][4]uint8{{255, 89, 155, 255}}, false},
+		}, nil}, [][4]uint8{{3, 51, 255, 255}}, false},
 		{"incorrect-type", args{[]byte{}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Type: gltf.AccessorMat2, ComponentType: gltf.ComponentUbyte,
 		}, nil}, nil, true},
@@ -664,18 +677,21 @@ func TestReadColor64(t *testing.T) {
 		{"[4]uint16", args{[]byte{0, 0, 255, 255, 0, 0, 255, 255}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort,
 		}, nil}, [][4]uint16{{0, 65535, 0, 65535}}, false},
-		{"[4]float32", args{[]byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64}, &gltf.Accessor{
+		{"[4]uint16-normalized", args{[]byte{37, 3, 180, 50, 255, 255, 255, 255}, &gltf.Accessor{
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
+		}, nil}, [][4]uint16{{805, 12980, 65535, 65535}}, false},
+		{"[4]float32", args{float32Bytes(0, 0.5, 1, 1), &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentFloat,
-		}, nil}, [][4]uint16{{65535, 23149, 40135, 65532}}, false},
+		}, nil}, [][4]uint16{{0, 32768, 65535, 65535}}, false},
 		{"[3]uint8", args{[]byte{0, 100, 200, 0}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUbyte,
 		}, nil}, [][4]uint16{{0, 25700, 51400, 65535}}, false},
 		{"[3]uint16", args{[]byte{0, 0, 255, 0, 255, 0, 0, 0}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort,
 		}, nil}, [][4]uint16{{0, 255, 255, 65535}}, false},
-		{"[3]float32", args{[]byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64}, &gltf.Accessor{
+		{"[3]float32", args{float32Bytes(805.0/65535.0, 12980.0/65535.0, 1), &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentFloat,
-		}, nil}, [][4]uint16{{65535, 23149, 40135, 65535}}, false},
+		}, nil}, [][4]uint16{{805, 12980, 65535, 65535}}, false},
 		{"incorrect-type", args{[]byte{}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Type: gltf.AccessorMat2, ComponentType: gltf.ComponentUbyte,
 		}, nil}, nil, true},


### PR DESCRIPTION
Fixes #95.

## Summary

- Make exported RGB/RGBA normalization helpers perform plain component scaling instead of sRGB transfer conversion.
- Keep modeler color reads consistent across FLOAT and normalized UNSIGNED_SHORT COLOR_0 accessors.
- Add regression coverage using the issue #95 color values so equivalent encodings decode to the same values.

## Verification

- Focused math normalization tests: 42 passed
- Focused ReadColor / ReadColor64 tests: 23 passed
- Full test suite: 567 passed
- Reporter repro: both GLBs decode the blue primitive as [[3 51 255 255] ...]