### PR TITLE
Fix reused accessor buffers

### DIFF
--- a/binary/slice.go
+++ b/binary/slice.go
@@ -145,6 +145,11 @@ func MakeSliceBuffer(c gltf.ComponentType, t gltf.AccessorType, count int, buffe
 		return nil, err
 	}
 	buffer = buffer[:cap(buffer)] // Extend the slice to its capacity.
+	// Reused backing storage may contain bytes from a previous accessor; reset it
+	// so callers get the same zero-value semantics as MakeSlice.
+	for i := range buffer {
+		buffer[i] = 0
+	}
 	if len(buffer) == 0 {
 		return MakeSlice(c, t, count)
 	}

--- a/binary/slice_test.go
+++ b/binary/slice_test.go
@@ -96,6 +96,7 @@ func TestMakeSliceBuffer(t *testing.T) {
 		{"small buffer", args{gltf.ComponentUbyte, gltf.AccessorVec2, 2, make([]uint8, 2)}, make([][2]uint8, 2)},
 		{"large buffer", args{gltf.ComponentUbyte, gltf.AccessorVec2, 2, make([]uint8, 6)}, make([][2]uint8, 2)},
 		{"same buffer", args{gltf.ComponentUbyte, gltf.AccessorVec2, 2, make([]uint8, 4)}, make([][2]uint8, 2)},
+		{"dirty buffer", args{gltf.ComponentUbyte, gltf.AccessorVec2, 2, []uint8{1, 2, 3, 4}}, make([][2]uint8, 2)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modeler/read_test.go
+++ b/modeler/read_test.go
@@ -591,6 +591,62 @@ func TestReadPosition(t *testing.T) {
 	}
 }
 
+func TestReadPosition_AfterReadNormalSparseNoBufferView(t *testing.T) {
+	positionValues := float32Bytes(1, 2, 3)
+	normalValues := float32Bytes(4, 5, 6, 7, 8, 9)
+	data := append([]byte{1, 0}, positionValues...)
+	data = append(data, normalValues...)
+
+	doc := &gltf.Document{
+		BufferViews: []*gltf.BufferView{
+			{Buffer: 0, ByteLength: 2},
+			{Buffer: 0, ByteOffset: 2, ByteLength: len(positionValues)},
+			{Buffer: 0, ByteOffset: 2 + len(positionValues), ByteLength: len(normalValues)},
+		},
+		Buffers: []*gltf.Buffer{
+			{Data: data, ByteLength: len(data)},
+		},
+	}
+	positionAccessor := &gltf.Accessor{
+		ComponentType: gltf.ComponentFloat,
+		Type:          gltf.AccessorVec3,
+		Count:         2,
+		Sparse: &gltf.Sparse{
+			Count: 1,
+			Indices: gltf.SparseIndices{
+				BufferView:    0,
+				ComponentType: gltf.ComponentUshort,
+			},
+			Values: gltf.SparseValues{BufferView: 1},
+		},
+	}
+	normalAccessor := &gltf.Accessor{
+		BufferView:    gltf.Index(2),
+		ComponentType: gltf.ComponentFloat,
+		Type:          gltf.AccessorVec3,
+		Count:         2,
+	}
+	wantPosition := [][3]float32{{0, 0, 0}, {1, 2, 3}}
+
+	gotPosition, err := modeler.ReadPosition(doc, positionAccessor, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotPosition, wantPosition) {
+		t.Errorf("ReadPosition() = %v, want %v", gotPosition, wantPosition)
+	}
+	if _, err := modeler.ReadNormal(doc, normalAccessor, nil); err != nil {
+		t.Fatal(err)
+	}
+	gotPosition, err = modeler.ReadPosition(doc, positionAccessor, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotPosition, wantPosition) {
+		t.Errorf("ReadPosition() after ReadNormal() = %v, want %v", gotPosition, wantPosition)
+	}
+}
+
 func TestReadColor(t *testing.T) {
 	type args struct {
 		data   []byte


### PR DESCRIPTION
Fixes #97.

## Summary
- clear reused backing storage in binary.MakeSliceBuffer so typed slices keep zero-value semantics
- add dirty-buffer coverage for MakeSliceBuffer
- add a ReadPosition-after-ReadNormal regression for sparse bufferless accessors

## Tests
- go test .\...