### PR TITLE
Tighten core glTF spec compliance

### DIFF
--- a/binary/encode.go
+++ b/binary/encode.go
@@ -40,8 +40,8 @@ func Read(b []byte, byteStride int, data any) error {
 			data[i] = color.RGBA64{R: c[0], G: c[1], B: c[2], A: c[3]}
 		}
 	case []int8:
-		for i, x := range b {
-			data[i] = int8(x)
+		for i := range data {
+			data[i] = Byte.Scalar(b[e*i:])
 		}
 	case [][2]int8:
 		for i := range data {
@@ -68,12 +68,8 @@ func Read(b []byte, byteStride int, data any) error {
 			data[i] = Byte.Mat4(b[e*i:])
 		}
 	case []uint8:
-		if byteStride != 1 {
-			copy(data, b)
-		} else {
-			for i := range data {
-				data[i] = Ubyte.Scalar(b[e*i:])
-			}
+		for i := range data {
+			data[i] = Ubyte.Scalar(b[e*i:])
 		}
 	case [][2]uint8:
 		for i := range data {
@@ -273,7 +269,13 @@ func Write(b []byte, stride int, data any) error {
 			Byte.PutMat4(b[e*i:], data[i])
 		}
 	case []uint8:
-		copy(b, data)
+		if e == 1 {
+			copy(b, data)
+		} else {
+			for i, x := range data {
+				Ubyte.PutScalar(b[e*i:], x)
+			}
+		}
 	case [][2]uint8:
 		for i := range data {
 			Ubyte.PutVec2(b[e*i:], data[i])

--- a/binary/encode_test.go
+++ b/binary/encode_test.go
@@ -63,8 +63,8 @@ func TestRead(t *testing.T) {
 		{"empty", args{make([]byte, 0), []int8{}}, []int8{}, false},
 		{"int8", args{buildBuffer1(4), make([]int8, 4)}, []int8{1, 2, 3, 4}, false},
 		{"int8-FE", args{[]byte{0xFE}, make([]int8, 1)}, []int8{-2}, false},
-		{"[2]int8", args{[]byte{1, 2, 0, 0, 3, 4, 0, 0}, make([][2]int8, 2)}, [][2]int8{{1, 2}, {3, 4}}, false},
-		{"[3]int8", args{[]byte{1, 2, 3, 0, 4, 5, 6, 0}, make([][3]int8, 2)}, [][3]int8{{1, 2, 3}, {4, 5, 6}}, false},
+		{"[2]int8", args{[]byte{1, 2, 3, 4}, make([][2]int8, 2)}, [][2]int8{{1, 2}, {3, 4}}, false},
+		{"[3]int8", args{[]byte{1, 2, 3, 4, 5, 6}, make([][3]int8, 2)}, [][3]int8{{1, 2, 3}, {4, 5, 6}}, false},
 		{"[4]int8", args{buildBuffer1(2 * 4), make([][4]int8, 2)}, [][4]int8{{1, 2, 3, 4}, {5, 6, 7, 8}}, false},
 		{"[2][2]int8", args{buildBuffer1(16, 2, 3, 6, 7, 10, 11, 14, 15), make([][2][2]int8, 2)}, [][2][2]int8{
 			{{1, 5}, {2, 6}},
@@ -80,8 +80,8 @@ func TestRead(t *testing.T) {
 		}, false},
 		{"uint8", args{buildBuffer1(4), make([]uint8, 4)}, []uint8{1, 2, 3, 4}, false},
 		{"uint8-FE", args{[]byte{0xFE}, make([]uint8, 1)}, []uint8{254}, false},
-		{"[2]uint8", args{[]byte{1, 2, 0, 0, 3, 4, 0, 0}, make([][2]uint8, 2)}, [][2]uint8{{1, 2}, {3, 4}}, false},
-		{"[3]uint8", args{[]byte{1, 2, 3, 0, 4, 5, 6, 0}, make([][3]uint8, 2)}, [][3]uint8{{1, 2, 3}, {4, 5, 6}}, false},
+		{"[2]uint8", args{[]byte{1, 2, 3, 4}, make([][2]uint8, 2)}, [][2]uint8{{1, 2}, {3, 4}}, false},
+		{"[3]uint8", args{[]byte{1, 2, 3, 4, 5, 6}, make([][3]uint8, 2)}, [][3]uint8{{1, 2, 3}, {4, 5, 6}}, false},
 		{"[4]uint8", args{buildBuffer1(2 * 4), make([][4]uint8, 2)}, [][4]uint8{{1, 2, 3, 4}, {5, 6, 7, 8}}, false},
 		{"[2][2]uint8", args{buildBuffer1(16, 2, 3, 6, 7, 10, 11), make([][2][2]uint8, 2)}, [][2][2]uint8{
 			{{1, 5}, {2, 6}},
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) {
 		{"int16", args{buildBuffer2(4), make([]int16, 4)}, []int16{1, 2, 3, 4}, false},
 		{"int16-FE", args{[]byte{0xFE, 0xFF}, make([]int16, 1)}, []int16{-2}, false},
 		{"[2]int16", args{buildBuffer2(2 * 2), make([][2]int16, 2)}, [][2]int16{{1, 2}, {3, 4}}, false},
-		{"[3]int16", args{[]byte{1, 0, 2, 0, 3, 0, 0, 0, 4, 0, 5, 0, 6, 0, 0, 0}, make([][3]int16, 2)}, [][3]int16{{1, 2, 3}, {4, 5, 6}}, false},
+		{"[3]int16", args{[]byte{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0}, make([][3]int16, 2)}, [][3]int16{{1, 2, 3}, {4, 5, 6}}, false},
 		{"[4]int16", args{buildBuffer2(2 * 4), make([][4]int16, 2)}, [][4]int16{{1, 2, 3, 4}, {5, 6, 7, 8}}, false},
 		{"[2][2]int16", args{buildBuffer2(2 * 2 * 2), make([][2][2]int16, 2)}, [][2][2]int16{
 			{{1, 3}, {2, 4}},
@@ -115,7 +115,7 @@ func TestRead(t *testing.T) {
 		{"uint16", args{buildBuffer2(4), make([]uint16, 4)}, []uint16{1, 2, 3, 4}, false},
 		{"uint16-FE", args{[]byte{0xFE, 0xFF}, make([]uint16, 1)}, []uint16{65534}, false},
 		{"[2]uint16", args{buildBuffer2(2 * 2), make([][2]uint16, 2)}, [][2]uint16{{1, 2}, {3, 4}}, false},
-		{"[3]uint16", args{[]byte{1, 0, 2, 0, 3, 0, 0, 0, 4, 0, 5, 0, 6, 0, 0, 0}, make([][3]uint16, 2)}, [][3]uint16{{1, 2, 3}, {4, 5, 6}}, false},
+		{"[3]uint16", args{[]byte{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0}, make([][3]uint16, 2)}, [][3]uint16{{1, 2, 3}, {4, 5, 6}}, false},
 		{"[4]uint16", args{buildBuffer2(2 * 4), make([][4]uint16, 2)}, [][4]uint16{{1, 2, 3, 4}, {5, 6, 7, 8}}, false},
 		{"[2][2]uint16", args{buildBuffer2(2 * 2 * 2), make([][2][2]uint16, 2)}, [][2][2]uint16{
 			{{1, 3}, {2, 4}},
@@ -193,8 +193,8 @@ func TestWrite(t *testing.T) {
 		{"empty", args{0, []int8{}}, []byte{}, false},
 		{"int8", args{4, []int8{1, 2, 3, 4}}, buildBuffer1(4), false},
 		{"int8-FE", args{1, []int8{-2}}, []byte{0xFE}, false},
-		{"[2]int8", args{8, [][2]int8{{1, 2}, {3, 4}}}, []byte{1, 2, 0, 0, 3, 4, 0, 0}, false},
-		{"[3]int8", args{8, [][3]int8{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 2, 3, 0, 4, 5, 6, 0}, false},
+		{"[2]int8", args{4, [][2]int8{{1, 2}, {3, 4}}}, []byte{1, 2, 3, 4}, false},
+		{"[3]int8", args{6, [][3]int8{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 2, 3, 4, 5, 6}, false},
 		{"[4]int8", args{8, [][4]int8{{1, 2, 3, 4}, {5, 6, 7, 8}}}, buildBuffer1(2 * 4), false},
 		{"[2][2]int8", args{16, [][2][2]int8{
 			{{1, 5}, {2, 6}},
@@ -210,8 +210,8 @@ func TestWrite(t *testing.T) {
 		}}, buildBuffer1(2 * 4 * 4), false},
 		{"uint8", args{4, []uint8{1, 2, 3, 4}}, buildBuffer1(4), false},
 		{"uint8-FE", args{1, []uint8{254}}, []byte{0xFE}, false},
-		{"[2]uint8", args{8, [][2]uint8{{1, 2}, {3, 4}}}, []byte{1, 2, 0, 0, 3, 4, 0, 0}, false},
-		{"[3]uint8", args{8, [][3]uint8{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 2, 3, 0, 4, 5, 6, 0}, false},
+		{"[2]uint8", args{4, [][2]uint8{{1, 2}, {3, 4}}}, []byte{1, 2, 3, 4}, false},
+		{"[3]uint8", args{6, [][3]uint8{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 2, 3, 4, 5, 6}, false},
 		{"[4]uint8", args{8, [][4]uint8{{1, 2, 3, 4}, {5, 6, 7, 8}}}, buildBuffer1(2 * 4), false},
 		{"[2][2]uint8", args{16, [][2][2]uint8{
 			{{1, 5}, {2, 6}},
@@ -228,7 +228,7 @@ func TestWrite(t *testing.T) {
 		{"int16", args{8, []int16{1, 2, 3, 4}}, buildBuffer2(4), false},
 		{"int16-FE", args{2, []int16{-2}}, []byte{0xFE, 0xFF}, false},
 		{"[2]int16", args{8, [][2]int16{{1, 2}, {3, 4}}}, buildBuffer2(2 * 2), false},
-		{"[3]int16", args{16, [][3]int16{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 0, 2, 0, 3, 0, 0, 0, 4, 0, 5, 0, 6, 0, 0, 0}, false},
+		{"[3]int16", args{12, [][3]int16{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0}, false},
 		{"[4]int16", args{16, [][4]int16{{1, 2, 3, 4}, {5, 6, 7, 8}}}, buildBuffer2(2 * 4), false},
 		{"[2][2]int16", args{16, [][2][2]int16{
 			{{1, 3}, {2, 4}},
@@ -245,7 +245,7 @@ func TestWrite(t *testing.T) {
 		{"uint16", args{8, []uint16{1, 2, 3, 4}}, buildBuffer2(4), false},
 		{"uint16-FE", args{2, []uint16{65534}}, []byte{0xFE, 0xFF}, false},
 		{"[2]uint16", args{8, [][2]uint16{{1, 2}, {3, 4}}}, buildBuffer2(2 * 2), false},
-		{"[3]uint16", args{16, [][3]uint16{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 0, 2, 0, 3, 0, 0, 0, 4, 0, 5, 0, 6, 0, 0, 0}, false},
+		{"[3]uint16", args{12, [][3]uint16{{1, 2, 3}, {4, 5, 6}}}, []byte{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0}, false},
 		{"[4]uint16", args{16, [][4]uint16{{1, 2, 3, 4}, {5, 6, 7, 8}}}, buildBuffer2(2 * 4), false},
 		{"[2][2]uint16", args{16, [][2][2]uint16{
 			{{1, 3}, {2, 4}},

--- a/const.go
+++ b/const.go
@@ -66,7 +66,7 @@ func (c *ComponentType) UnmarshalJSON(data []byte) error {
 	var tmp uint16
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*c = map[uint16]ComponentType{
+		ct, ok := map[uint16]ComponentType{
 			5120: ComponentByte,
 			5121: ComponentUbyte,
 			5122: ComponentShort,
@@ -74,20 +74,28 @@ func (c *ComponentType) UnmarshalJSON(data []byte) error {
 			5125: ComponentUint,
 			5126: ComponentFloat,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown component type: %d", tmp)
+		}
+		*c = ct
 	}
 	return err
 }
 
 // MarshalJSON marshal the component type with the correct default values.
 func (c *ComponentType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[ComponentType]uint16{
+	ct, ok := map[ComponentType]uint16{
 		ComponentByte:   5120,
 		ComponentUbyte:  5121,
 		ComponentShort:  5122,
 		ComponentUshort: 5123,
 		ComponentUint:   5125,
 		ComponentFloat:  5126,
-	}[*c])
+	}[*c]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown component type: %d", *c)
+	}
+	return json.Marshal(ct)
 }
 
 // AccessorType specifies if the attribute is a scalar, vector, or matrix.
@@ -140,7 +148,7 @@ func (a *AccessorType) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON marshal the accessor type with the correct default values.
 func (a *AccessorType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[AccessorType]string{
+	accType, ok := map[AccessorType]string{
 		AccessorScalar: "SCALAR",
 		AccessorVec2:   "VEC2",
 		AccessorVec3:   "VEC3",
@@ -148,7 +156,11 @@ func (a *AccessorType) MarshalJSON() ([]byte, error) {
 		AccessorMat2:   "MAT2",
 		AccessorMat3:   "MAT3",
 		AccessorMat4:   "MAT4",
-	}[*a])
+	}[*a]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown accessor's type: %d", *a)
+	}
+	return json.Marshal(accType)
 }
 
 // The Target that the GPU buffer should be bound to.
@@ -181,7 +193,7 @@ func (p *PrimitiveMode) UnmarshalJSON(data []byte) error {
 	var tmp uint8
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*p = map[uint8]PrimitiveMode{
+		mode, ok := map[uint8]PrimitiveMode{
 			0: PrimitivePoints,
 			1: PrimitiveLines,
 			2: PrimitiveLineLoop,
@@ -190,13 +202,17 @@ func (p *PrimitiveMode) UnmarshalJSON(data []byte) error {
 			5: PrimitiveTriangleStrip,
 			6: PrimitiveTriangleFan,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown primitive mode: %d", tmp)
+		}
+		*p = mode
 	}
 	return err
 }
 
 // MarshalJSON marshal the primitive mode with the correct default values.
 func (p *PrimitiveMode) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[PrimitiveMode]uint8{
+	mode, ok := map[PrimitiveMode]uint8{
 		PrimitivePoints:        0,
 		PrimitiveLines:         1,
 		PrimitiveLineLoop:      2,
@@ -204,7 +220,11 @@ func (p *PrimitiveMode) MarshalJSON() ([]byte, error) {
 		PrimitiveTriangles:     4,
 		PrimitiveTriangleStrip: 5,
 		PrimitiveTriangleFan:   6,
-	}[*p])
+	}[*p]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown primitive mode: %d", *p)
+	}
+	return json.Marshal(mode)
 }
 
 // The AlphaMode enumeration specifying the interpretation of the alpha value of the main factor and texture.
@@ -221,22 +241,30 @@ func (a *AlphaMode) UnmarshalJSON(data []byte) error {
 	var tmp string
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*a = map[string]AlphaMode{
+		mode, ok := map[string]AlphaMode{
 			"OPAQUE": AlphaOpaque,
 			"MASK":   AlphaMask,
 			"BLEND":  AlphaBlend,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown alpha mode: %s", tmp)
+		}
+		*a = mode
 	}
 	return err
 }
 
 // MarshalJSON marshal the alpha mode with the correct default values.
 func (a *AlphaMode) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[AlphaMode]string{
+	mode, ok := map[AlphaMode]string{
 		AlphaOpaque: "OPAQUE",
 		AlphaMask:   "MASK",
 		AlphaBlend:  "BLEND",
-	}[*a])
+	}[*a]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown alpha mode: %d", *a)
+	}
+	return json.Marshal(mode)
 }
 
 // MagFilter is the magnification filter.
@@ -253,20 +281,28 @@ func (m *MagFilter) UnmarshalJSON(data []byte) error {
 	var tmp uint16
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*m = map[uint16]MagFilter{
+		filter, ok := map[uint16]MagFilter{
 			9728: MagNearest,
 			9729: MagLinear,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown magnification filter: %d", tmp)
+		}
+		*m = filter
 	}
 	return err
 }
 
 // MarshalJSON marshal the alpha mode with the correct default values.
 func (m *MagFilter) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[MagFilter]uint16{
+	filter, ok := map[MagFilter]uint16{
 		MagNearest: 9728,
 		MagLinear:  9729,
-	}[*m])
+	}[*m]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown magnification filter: %d", *m)
+	}
+	return json.Marshal(filter)
 }
 
 // MinFilter is the minification filter.
@@ -287,7 +323,7 @@ func (m *MinFilter) UnmarshalJSON(data []byte) error {
 	var tmp uint16
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*m = map[uint16]MinFilter{
+		filter, ok := map[uint16]MinFilter{
 			9728: MinNearest,
 			9729: MinLinear,
 			9984: MinNearestMipMapNearest,
@@ -295,20 +331,28 @@ func (m *MinFilter) UnmarshalJSON(data []byte) error {
 			9986: MinNearestMipMapLinear,
 			9987: MinLinearMipMapLinear,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown minification filter: %d", tmp)
+		}
+		*m = filter
 	}
 	return err
 }
 
 // MarshalJSON marshal the min filter with the correct default values.
 func (m *MinFilter) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[MinFilter]uint16{
+	filter, ok := map[MinFilter]uint16{
 		MinNearest:              9728,
 		MinLinear:               9729,
 		MinNearestMipMapNearest: 9984,
 		MinLinearMipMapNearest:  9985,
 		MinNearestMipMapLinear:  9986,
 		MinLinearMipMapLinear:   9987,
-	}[*m])
+	}[*m]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown minification filter: %d", *m)
+	}
+	return json.Marshal(filter)
 }
 
 // WrappingMode is the wrapping mode of a texture.
@@ -325,22 +369,30 @@ func (w *WrappingMode) UnmarshalJSON(data []byte) error {
 	var tmp uint16
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*w = map[uint16]WrappingMode{
+		mode, ok := map[uint16]WrappingMode{
 			33071: WrapClampToEdge,
 			33648: WrapMirroredRepeat,
 			10497: WrapRepeat,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown wrapping mode: %d", tmp)
+		}
+		*w = mode
 	}
 	return err
 }
 
 // MarshalJSON marshal the wrapping mode with the correct default values.
 func (w *WrappingMode) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[WrappingMode]uint16{
+	mode, ok := map[WrappingMode]uint16{
 		WrapClampToEdge:    33071,
 		WrapMirroredRepeat: 33648,
 		WrapRepeat:         10497,
-	}[*w])
+	}[*w]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown wrapping mode: %d", *w)
+	}
+	return json.Marshal(mode)
 }
 
 // Interpolation algorithm.
@@ -357,22 +409,30 @@ func (i *Interpolation) UnmarshalJSON(data []byte) error {
 	var tmp string
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*i = map[string]Interpolation{
+		interpolation, ok := map[string]Interpolation{
 			"LINEAR":      InterpolationLinear,
 			"STEP":        InterpolationStep,
 			"CUBICSPLINE": InterpolationCubicSpline,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown interpolation: %s", tmp)
+		}
+		*i = interpolation
 	}
 	return err
 }
 
 // MarshalJSON marshal the interpolation with the correct default values.
 func (i *Interpolation) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[Interpolation]string{
+	interpolation, ok := map[Interpolation]string{
 		InterpolationLinear:      "LINEAR",
 		InterpolationStep:        "STEP",
 		InterpolationCubicSpline: "CUBICSPLINE",
-	}[*i])
+	}[*i]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown interpolation: %d", *i)
+	}
+	return json.Marshal(interpolation)
 }
 
 // TRSProperty defines a local space transformation.
@@ -391,24 +451,32 @@ func (t *TRSProperty) UnmarshalJSON(data []byte) error {
 	var tmp string
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
-		*t = map[string]TRSProperty{
+		trs, ok := map[string]TRSProperty{
 			"translation": TRSTranslation,
 			"rotation":    TRSRotation,
 			"scale":       TRSScale,
 			"weights":     TRSWeights,
 		}[tmp]
+		if !ok {
+			return fmt.Errorf("gltf: unknown TRS property: %s", tmp)
+		}
+		*t = trs
 	}
 	return err
 }
 
 // MarshalJSON marshal the TRSProperty with the correct default values.
 func (t *TRSProperty) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[TRSProperty]string{
+	trs, ok := map[TRSProperty]string{
 		TRSTranslation: "translation",
 		TRSRotation:    "rotation",
 		TRSScale:       "scale",
 		TRSWeights:     "weights",
-	}[*t])
+	}[*t]
+	if !ok {
+		return nil, fmt.Errorf("gltf: unknown TRS property: %d", *t)
+	}
+	return json.Marshal(trs)
 }
 
 const (
@@ -430,7 +498,8 @@ type glbHeader struct {
 }
 
 const (
-	mimetypeApplicationOctet = "data:application/octet-stream;base64"
-	mimetypeImagePNG         = "data:image/png;base64"
-	mimetypeImageJPG         = "data:image/jpeg;base64"
+	mimetypeApplicationOctet      = "data:application/octet-stream;base64"
+	mimetypeApplicationGltfBuffer = "data:application/gltf-buffer;base64"
+	mimetypeImagePNG              = "data:image/png;base64"
+	mimetypeImageJPG              = "data:image/jpeg;base64"
 )

--- a/decoder.go
+++ b/decoder.go
@@ -62,21 +62,6 @@ func (d *Decoder) Decode(doc *Document) error {
 		return err
 	}
 
-	for _, b := range doc.Buffers {
-		if !b.IsEmbeddedResource() {
-			if uri, ok := sanitizeURI(b.URI); ok {
-				b.URI = uri
-			}
-		}
-	}
-	for _, im := range doc.Images {
-		if !im.IsEmbeddedResource() {
-			if uri, ok := sanitizeURI(im.URI); ok {
-				im.URI = uri
-			}
-		}
-	}
-
 	var externalBufferIndex = 0
 	if isBinary && len(doc.Buffers) > 0 && doc.Buffers[0].URI == "" {
 		externalBufferIndex = 1
@@ -129,7 +114,7 @@ func (d *Decoder) readGLBHeader() (*glbHeader, error) {
 }
 
 func (d *Decoder) validateGLBHeader(header *glbHeader) error {
-	if header.JSONHeader.Type != glbChunkJSON || (header.JSONHeader.Length+uint32(binary.Size(header))) > header.Length {
+	if header.Version != 2 || header.JSONHeader.Type != glbChunkJSON || (header.JSONHeader.Length+uint32(binary.Size(header))) > header.Length {
 		return errors.New("gltf: Invalid GLB JSON header")
 	}
 	return nil
@@ -154,9 +139,13 @@ func (d *Decoder) decodeBuffer(buffer *Buffer) error {
 	if buffer.IsEmbeddedResource() {
 		buffer.Data, err = buffer.marshalData()
 	} else {
-		err = validateBufferURI(buffer.URI)
+		uri := buffer.URI
+		if sanitized, ok := sanitizeURI(uri); ok {
+			uri = sanitized
+		}
+		err = validateBufferURI(uri)
 		if err == nil && d.Fsys != nil {
-			buffer.Data, err = fs.ReadFile(d.Fsys, buffer.URI)
+			buffer.Data, err = fs.ReadFile(d.Fsys, uri)
 			if len(buffer.Data) > int(buffer.ByteLength) {
 				buffer.Data = buffer.Data[:buffer.ByteLength:buffer.ByteLength]
 			}
@@ -176,7 +165,7 @@ func (d *Decoder) decodeBinaryBuffer(buffer *Buffer) error {
 	if err != nil {
 		return err
 	}
-	if header.Type != glbChunkBIN || header.Length < uint32(buffer.ByteLength) {
+	if header.Type != glbChunkBIN || header.Length < uint32(buffer.ByteLength) || header.Length > uint32(buffer.ByteLength+3) {
 		return errors.New("gltf: Invalid GLB BIN header")
 	}
 	buffer.Data = make([]byte, buffer.ByteLength)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -67,8 +67,8 @@ func TestOpen(t *testing.T) {
 			},
 			Buffers: []*Buffer{{ByteLength: 60, URI: "simpleSquare.bin", Data: readFile("testdata/Cameras/glTF/simpleSquare.bin")}},
 			Cameras: []*Camera{
-				{Perspective: &Perspective{AspectRatio: Float(1.0), Yfov: 0.7, Zfar: Float(100), Znear: 0.01}},
-				{Orthographic: &Orthographic{Xmag: 1.0, Ymag: 1.0, Zfar: 100, Znear: 0.01}},
+				{Type: "perspective", Perspective: &Perspective{AspectRatio: Float(1.0), Yfov: 0.7, Zfar: Float(100), Znear: 0.01}},
+				{Type: "orthographic", Orthographic: &Orthographic{Xmag: 1.0, Ymag: 1.0, Zfar: 100, Znear: 0.01}},
 			},
 			Meshes: []*Mesh{{Primitives: []*Primitive{{Indices: Index(0), Mode: PrimitiveTriangles, Attributes: PrimitiveAttributes{POSITION: 1}}}}},
 			Nodes: []*Node{
@@ -124,9 +124,9 @@ func TestOpen(t *testing.T) {
 			},
 			Buffers: []*Buffer{{ByteLength: 840, URI: "Box With Spaces.bin", Data: readFile("testdata/Box With Spaces/glTF/Box With Spaces.bin")}},
 			Images: []*Image{
-				{Name: "Normal Map", MimeType: "image/png", URI: "Normal Map.png"},
-				{Name: "glTF Logo With Spaces", MimeType: "image/png", URI: "glTF Logo With Spaces.png"},
-				{Name: "Roughness Metallic", MimeType: "image/png", URI: "Roughness Metallic.png"},
+				{Name: "Normal Map", MimeType: "image/png", URI: "Normal%20Map.png"},
+				{Name: "glTF Logo With Spaces", MimeType: "image/png", URI: "glTF%20Logo%20With%20Spaces.png"},
+				{Name: "Roughness Metallic", MimeType: "image/png", URI: "Roughness%20Metallic.png"},
 			},
 			Materials: []*Material{{
 				Name: "Material", AlphaMode: AlphaOpaque, AlphaCutoff: Float(0.5), NormalTexture: &NormalTexture{Index: Index(0), Scale: Float(1)}, PBRMetallicRoughness: &PBRMetallicRoughness{
@@ -245,7 +245,7 @@ func TestDecoder_Decode(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"baseJSON", NewDecoderFS(bytes.NewBufferString("{\"buffers\": [{\"byteLength\": 1, \"URI\": \"a.bin\"}]}"), fstest.MapFS{"a.bin": &fstest.MapFile{Data: []byte("abcdfg")}}), args{new(Document)}, false},
+		{"baseJSON", NewDecoderFS(bytes.NewBufferString("{\"asset\":{\"version\":\"2.0\"},\"buffers\": [{\"byteLength\": 1, \"URI\": \"a.bin\"}]}"), fstest.MapFS{"a.bin": &fstest.MapFile{Data: []byte("abcdfg")}}), args{new(Document)}, false},
 		{"onlyGLBHeader", NewDecoderFS(bytes.NewBuffer([]byte{0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x00, 0x00, 0x5c, 0x06, 0x00, 0x00, 0x4a, 0x53, 0x4f, 0x4e}), fstest.MapFS{"a.bin": &fstest.MapFile{Data: []byte("abcdfg")}}), args{new(Document)}, true},
 		{"glbNoJSONChunk", NewDecoderFS(bytes.NewBuffer([]byte{0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x00, 0x00, 0x5c, 0x06, 0x00, 0x00, 0x4a, 0x52, 0x4f, 0x4e}), fstest.MapFS{"a.bin": &fstest.MapFile{Data: []byte("abcdfg")}}), args{new(Document)}, true},
 		{"empty", NewDecoder(bytes.NewBufferString("")), args{new(Document)}, true},

--- a/encode.go
+++ b/encode.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -167,6 +168,9 @@ func (e *Encoder) encodeBinary(doc *Document) (bool, error) {
 	hasBinChunk := len(doc.Buffers) > 0 && doc.Buffers[0].URI == ""
 	var binPaddedLength int
 	if hasBinChunk {
+		if len(doc.Buffers[0].Data) < doc.Buffers[0].ByteLength {
+			return false, io.ErrShortBuffer
+		}
 		binPaddedLength = ((doc.Buffers[0].ByteLength + 3) / 4) * 4
 		header.Length += uint32(8 + binPaddedLength)
 	}
@@ -186,7 +190,7 @@ func (e *Encoder) encodeBinary(doc *Document) (bool, error) {
 		}
 		binHeader := chunkHeader{Length: uint32(binPaddedLength), Type: glbChunkBIN}
 		binary.Write(e.w, binary.LittleEndian, &binHeader)
-		e.w.Write(binBuffer.Data)
+		e.w.Write(binBuffer.Data[:binBuffer.ByteLength])
 		_, err = e.w.Write(binPadding)
 	}
 
@@ -231,12 +235,39 @@ func (e *Encoder) marshalJSONDoc(doc *Document) ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
+// UnmarshalJSON unmarshals the document and validates root-level required fields.
+func (doc *Document) UnmarshalJSON(data []byte) error {
+	type alias Document
+	var required struct {
+		Asset *json.RawMessage `json:"asset"`
+	}
+	if err := json.Unmarshal(data, &required); err != nil {
+		return err
+	}
+	if required.Asset == nil {
+		return errors.New("gltf: asset is required")
+	}
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*doc = Document(tmp)
+	return nil
+}
+
 // UnmarshalJSON unmarshal the asset with the correct default values.
 func (as *Asset) UnmarshalJSON(data []byte) error {
 	type alias Asset
-	tmp := alias(Asset{
-		Version: "2.0",
-	})
+	var required struct {
+		Version *string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &required); err != nil {
+		return err
+	}
+	if required.Version == nil || *required.Version == "" {
+		return errors.New("gltf: asset.version is required")
+	}
+	var tmp alias
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
 		*as = Asset(tmp)
@@ -247,21 +278,56 @@ func (as *Asset) UnmarshalJSON(data []byte) error {
 // MarshalJSON marshal the asset with the correct default values.
 func (as *Asset) MarshalJSON() ([]byte, error) {
 	type alias Asset
-	if as.Version == "" {
-		return json.Marshal(&struct {
-			Version string `json:"version,omitempty"`
-			*alias
-		}{
-			Version: "2.0",
-			alias:   (*alias)(as),
-		})
+	tmp := alias(*as)
+	if tmp.Version == "" {
+		tmp.Version = "2.0"
 	}
-	return json.Marshal((*alias)(as))
+	return json.Marshal(tmp)
+}
+
+// UnmarshalJSON unmarshal the accessor and validates required fields.
+func (a *Accessor) UnmarshalJSON(data []byte) error {
+	type alias Accessor
+	var required struct {
+		ComponentType *json.RawMessage `json:"componentType"`
+		Count         *int             `json:"count"`
+		Type          *json.RawMessage `json:"type"`
+	}
+	if err := json.Unmarshal(data, &required); err != nil {
+		return err
+	}
+	if required.ComponentType == nil {
+		return errors.New("gltf: accessor.componentType is required")
+	}
+	if required.Count == nil || *required.Count < 1 {
+		return errors.New("gltf: accessor.count must be greater than zero")
+	}
+	if required.Type == nil {
+		return errors.New("gltf: accessor.type is required")
+	}
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*a = Accessor(tmp)
+	return nil
 }
 
 // UnmarshalJSON unmarshal the node with the correct default values.
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type alias Node
+	var raw struct {
+		Matrix      *json.RawMessage `json:"matrix"`
+		Rotation    *json.RawMessage `json:"rotation"`
+		Scale       *json.RawMessage `json:"scale"`
+		Translation *json.RawMessage `json:"translation"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Matrix != nil && (raw.Rotation != nil || raw.Scale != nil || raw.Translation != nil) {
+		return errors.New("gltf: node must not define both matrix and TRS properties")
+	}
 	tmp := alias(Node{
 		Matrix:   DefaultMatrix,
 		Rotation: DefaultRotation,
@@ -286,47 +352,135 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 	}{
 		alias: (*alias)(n),
 	}
-	if n.Matrix != DefaultMatrix && n.Matrix != emptyMatrix {
+	hasMatrix := n.Matrix != DefaultMatrix && n.Matrix != emptyMatrix
+	hasRotation := n.Rotation != DefaultRotation && n.Rotation != emptyRotation
+	hasScale := n.Scale != DefaultScale && n.Scale != emptyScale
+	hasTranslation := n.Translation != DefaultTranslation
+	if hasMatrix && (hasRotation || hasScale || hasTranslation) {
+		return nil, errors.New("gltf: node must not define both matrix and TRS properties")
+	}
+	if hasMatrix {
 		tmp.Matrix = &n.Matrix
 	}
-	if n.Rotation != DefaultRotation && n.Rotation != emptyRotation {
+	if hasRotation {
 		tmp.Rotation = &n.Rotation
 	}
-	if n.Scale != DefaultScale && n.Scale != emptyScale {
+	if hasScale {
 		tmp.Scale = &n.Scale
 	}
-	if n.Translation != DefaultTranslation {
+	if hasTranslation {
 		tmp.Translation = &n.Translation
 	}
 	return json.Marshal(tmp)
 }
 
+// UnmarshalJSON unmarshal the skin and validates required fields.
+func (s *Skin) UnmarshalJSON(data []byte) error {
+	type alias Skin
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if len(tmp.Joints) == 0 {
+		return errors.New("gltf: skin.joints is required")
+	}
+	*s = Skin(tmp)
+	return nil
+}
+
+// UnmarshalJSON unmarshal the camera and validates its declared type.
+func (c *Camera) UnmarshalJSON(data []byte) error {
+	type alias Camera
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if tmp.Perspective != nil && tmp.Orthographic != nil {
+		return errors.New("gltf: camera must not define both perspective and orthographic properties")
+	}
+	switch tmp.Type {
+	case "perspective":
+		if tmp.Perspective == nil {
+			return errors.New("gltf: perspective camera must define the perspective property")
+		}
+	case "orthographic":
+		if tmp.Orthographic == nil {
+			return errors.New("gltf: orthographic camera must define the orthographic property")
+		}
+	case "":
+		return errors.New("gltf: camera.type is required")
+	default:
+		return fmt.Errorf("gltf: unknown camera type: %s", tmp.Type)
+	}
+	*c = Camera(tmp)
+	return nil
+}
+
 // MarshalJSON marshal the camera with the correct default values.
 func (c *Camera) MarshalJSON() ([]byte, error) {
 	type alias Camera
-	if c.Perspective != nil {
-		return json.Marshal(&struct {
-			Type string `json:"type"`
-			*alias
-		}{
-			Type:  "perspective",
-			alias: (*alias)(c),
-		})
-	} else if c.Orthographic != nil {
-		return json.Marshal(&struct {
-			Type string `json:"type"`
-			*alias
-		}{
-			Type:  "orthographic",
-			alias: (*alias)(c),
-		})
+	if c.Perspective != nil && c.Orthographic != nil {
+		return nil, errors.New("gltf: camera must not define both perspective and orthographic properties")
 	}
-	return nil, errors.New("gltf: camera must defined either the perspective or orthographic property")
+	tmp := alias(*c)
+	var cameraType string
+	if c.Perspective != nil {
+		cameraType = "perspective"
+	} else if c.Orthographic != nil {
+		cameraType = "orthographic"
+	} else {
+		return nil, errors.New("gltf: camera must define either the perspective or orthographic property")
+	}
+	if tmp.Type == "" {
+		c.Type = cameraType
+		tmp.Type = cameraType
+	} else if tmp.Type != cameraType {
+		return nil, fmt.Errorf("gltf: camera type %q does not match %s property", tmp.Type, cameraType)
+	}
+	return json.Marshal(tmp)
+}
+
+// UnmarshalJSON unmarshal the mesh and validates required fields.
+func (m *Mesh) UnmarshalJSON(data []byte) error {
+	type alias Mesh
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if len(tmp.Primitives) == 0 {
+		return errors.New("gltf: mesh.primitives is required")
+	}
+	*m = Mesh(tmp)
+	return nil
+}
+
+// UnmarshalJSON unmarshal the primitive and validates required fields.
+func (p *Primitive) UnmarshalJSON(data []byte) error {
+	type alias Primitive
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if len(tmp.Attributes) == 0 {
+		return errors.New("gltf: primitive.attributes is required")
+	}
+	*p = Primitive(tmp)
+	return nil
 }
 
 // UnmarshalJSON unmarshal the material with the correct default values.
 func (m *Material) UnmarshalJSON(data []byte) error {
 	type alias Material
+	var raw struct {
+		AlphaMode   *json.RawMessage `json:"alphaMode"`
+		AlphaCutoff *json.RawMessage `json:"alphaCutoff"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.AlphaCutoff != nil && raw.AlphaMode == nil {
+		return errors.New("gltf: material.alphaCutoff requires alphaMode")
+	}
 	tmp := alias(Material{AlphaCutoff: Float(0.5)})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
@@ -346,6 +500,9 @@ func (m *Material) MarshalJSON() ([]byte, error) {
 		alias: (*alias)(m),
 	}
 	if m.AlphaCutoff != nil && *m.AlphaCutoff != 0.5 {
+		if m.AlphaMode == AlphaOpaque {
+			return nil, errors.New("gltf: material.alphaCutoff requires alphaMode")
+		}
 		tmp.AlphaCutoff = m.AlphaCutoff
 	}
 	if m.EmissiveFactor != [3]float64{0, 0, 0} {
@@ -360,6 +517,9 @@ func (n *NormalTexture) UnmarshalJSON(data []byte) error {
 	tmp := alias(NormalTexture{Scale: Float(1)})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
+		if tmp.Index == nil {
+			return errors.New("gltf: normalTexture.index is required")
+		}
 		*n = NormalTexture(tmp)
 	}
 	return err
@@ -368,6 +528,9 @@ func (n *NormalTexture) UnmarshalJSON(data []byte) error {
 // MarshalJSON marshal the texture info with the correct default values.
 func (n *NormalTexture) MarshalJSON() ([]byte, error) {
 	type alias NormalTexture
+	if n.Index == nil {
+		return nil, errors.New("gltf: normalTexture.index is required")
+	}
 	if n.Scale != nil && *n.Scale == 1 {
 		return json.Marshal(&struct {
 			Scale float64 `json:"scale,omitempty"`
@@ -386,6 +549,9 @@ func (o *OcclusionTexture) UnmarshalJSON(data []byte) error {
 	tmp := alias(OcclusionTexture{Strength: Float(1)})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
+		if tmp.Index == nil {
+			return errors.New("gltf: occlusionTexture.index is required")
+		}
 		*o = OcclusionTexture(tmp)
 	}
 	return err
@@ -394,6 +560,9 @@ func (o *OcclusionTexture) UnmarshalJSON(data []byte) error {
 // MarshalJSON marshal the texture info with the correct default values.
 func (o *OcclusionTexture) MarshalJSON() ([]byte, error) {
 	type alias OcclusionTexture
+	if o.Index == nil {
+		return nil, errors.New("gltf: occlusionTexture.index is required")
+	}
 	if o.Strength != nil && *o.Strength == 1 {
 		return json.Marshal(&struct {
 			Strength float64 `json:"strength,omitempty"`
@@ -404,6 +573,26 @@ func (o *OcclusionTexture) MarshalJSON() ([]byte, error) {
 		})
 	}
 	return json.Marshal((*alias)(o))
+}
+
+// UnmarshalJSON unmarshal the texture info and validates required fields.
+func (t *TextureInfo) UnmarshalJSON(data []byte) error {
+	type alias TextureInfo
+	var required struct {
+		Index *int `json:"index"`
+	}
+	if err := json.Unmarshal(data, &required); err != nil {
+		return err
+	}
+	if required.Index == nil {
+		return errors.New("gltf: textureInfo.index is required")
+	}
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*t = TextureInfo(tmp)
+	return nil
 }
 
 // UnmarshalJSON unmarshal the pbr with the correct default values.

--- a/encode_test.go
+++ b/encode_test.go
@@ -76,7 +76,7 @@ func TestEncoder_Encode_AsBinary_WithoutBuffer(t *testing.T) {
 }
 
 func TestEncoder_Encode_AsBinary_WithoutBinChunk(t *testing.T) {
-	doc := &Document{Buffers: []*Buffer{
+	doc := &Document{Asset: Asset{Version: "2.0"}, Buffers: []*Buffer{
 		{Extras: 8.0, Name: "embedded", ByteLength: 2, URI: "data:application/octet-stream;base64,YW55ICsgb2xkICYgZGF0YQ==", Data: []byte("any + old & data")},
 		{Extras: 8.0, Name: "external", ByteLength: 4, URI: "b.bin", Data: []byte{4, 5, 6, 7}},
 		{Extras: 8.0, Name: "external", ByteLength: 4, URI: "a.drc", Data: []byte{0, 0, 0, 0}},
@@ -94,7 +94,7 @@ func TestEncoder_Encode_AsBinary_WithoutBinChunk(t *testing.T) {
 }
 
 func TestEncoder_Encode_AsBinary_WithBinChunk(t *testing.T) {
-	doc := &Document{Buffers: []*Buffer{
+	doc := &Document{Asset: Asset{Version: "2.0"}, Buffers: []*Buffer{
 		{Extras: 8.0, Name: "binary", ByteLength: 3, Data: []byte{1, 2, 3}},
 	}}
 	buff := new(bytes.Buffer)
@@ -120,7 +120,7 @@ func TestEncoder_Encode_AsBinary_WithBinChunk(t *testing.T) {
 }
 
 func TestEncoder_Encode_Buffers_Without_URI(t *testing.T) {
-	doc := &Document{Buffers: []*Buffer{
+	doc := &Document{Asset: Asset{Version: "2.0"}, Buffers: []*Buffer{
 		{Name: "binary", ByteLength: 3, Data: []byte{1, 2, 3}},
 		{Name: "binary2", ByteLength: 3, Data: []byte{4, 5, 6}},
 	}}
@@ -214,17 +214,19 @@ func TestEncoder_Encode(t *testing.T) {
 			{Extras: 8.0, Name: "emmisice", AlphaCutoff: Float(0.5), AlphaMode: AlphaMask, EmissiveTexture: &TextureInfo{Extras: 8.0, Index: 4, TexCoord: 50}},
 		}}}, false},
 		{"withMeshes", args{&Document{Meshes: []*Mesh{
-			{Extras: 8.0, Name: "mesh_1", Weights: []float64{1.2, 2}},
+			{Extras: 8.0, Name: "mesh_1", Primitives: []*Primitive{{Attributes: PrimitiveAttributes{POSITION: 1}}}, Weights: []float64{1.2, 2}},
 			{Extras: 8.0, Name: "mesh_2", Primitives: []*Primitive{
 				{Extras: 8.0, Attributes: PrimitiveAttributes{POSITION: 1}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
-				{Extras: 8.0, Targets: []PrimitiveAttributes{{POSITION: 1, "THEN": 4}, {"OTHER": 2}}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
+				{Extras: 8.0, Attributes: PrimitiveAttributes{POSITION: 1}, Targets: []PrimitiveAttributes{{POSITION: 1, "THEN": 4}, {"OTHER": 2}}, Indices: Index(2), Material: Index(1), Mode: PrimitiveLines},
 			}},
 		}}}, false},
 		{"withNodes", args{&Document{Nodes: []*Node{
 			{Extras: 8.0, Name: "n-1", Camera: Index(1), Children: []int{1, 2}, Skin: Index(3),
-				Matrix: [16]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, Mesh: Index(15), Rotation: [4]float64{1.5, 1.3, 12, 0}, Scale: [3]float64{1, 3, 4}, Translation: [3]float64{0, 7.8, 9}, Weights: []float64{1, 3}},
+				Matrix: [16]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, Mesh: Index(15), Rotation: DefaultRotation, Scale: DefaultScale, Weights: []float64{1, 3}},
 			{Extras: 8.0, Name: "n-2", Camera: Index(1), Children: []int{1, 2}, Skin: Index(3),
 				Matrix: [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, Mesh: Index(15), Rotation: [4]float64{0, 0, 0, 1}, Scale: [3]float64{1, 1, 1}},
+			{Extras: 8.0, Name: "n-3", Camera: Index(1), Children: []int{1, 2}, Skin: Index(3),
+				Matrix: DefaultMatrix, Mesh: Index(15), Rotation: [4]float64{1.5, 1.3, 12, 0}, Scale: [3]float64{1, 3, 4}, Translation: [3]float64{0, 7.8, 9}, Weights: []float64{1, 3}},
 		}}}, false},
 		{"withSampler", args{&Document{Samplers: []*Sampler{
 			{Extras: 8.0, Name: "s_1", MagFilter: MagLinear, MinFilter: MinLinearMipMapLinear, WrapS: WrapClampToEdge, WrapT: WrapMirroredRepeat},
@@ -309,6 +311,30 @@ func TestImage_MarshalData(t *testing.T) {
 	}
 }
 
+func TestAsset_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		asset   *Asset
+		want    []byte
+		wantErr bool
+	}{
+		{"zero", &Asset{}, []byte(`{"version":"2.0"}`), false},
+		{"version", &Asset{Version: "2.1"}, []byte(`{"version":"2.1"}`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.asset.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Asset.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Asset.MarshalJSON() = %v, want %v", string(got), string(tt.want))
+			}
+		})
+	}
+}
+
 func TestNode_UnmarshalJSON(t *testing.T) {
 	type args struct {
 		data []byte
@@ -325,7 +351,7 @@ func TestNode_UnmarshalJSON(t *testing.T) {
 			Rotation: [4]float64{0, 0, 0, 1},
 			Scale:    [3]float64{1, 1, 1},
 		}, false},
-		{"nodefault", new(Node), args{[]byte(`{"matrix":[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],"rotation":[0,0,0,1],"scale":[1,1,1],"camera":0,"mesh":0,"skin":0}`)}, &Node{
+		{"matrix", new(Node), args{[]byte(`{"matrix":[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],"camera":0,"mesh":0,"skin":0}`)}, &Node{
 			Matrix:   [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
 			Rotation: [4]float64{0, 0, 0, 1},
 			Scale:    [3]float64{1, 1, 1},
@@ -333,14 +359,16 @@ func TestNode_UnmarshalJSON(t *testing.T) {
 			Mesh:     Index(0),
 			Skin:     Index(0),
 		}, false},
-		{"nodefault", new(Node), args{[]byte(`{"matrix":[1,2,2,0,0,1,3,4,0,0,1,0,5,0,0,5],"rotation":[1,2,3,4],"scale":[2,3,4],"camera":1,"mesh":2,"skin":3}`)}, &Node{
-			Matrix:   [16]float64{1, 2, 2, 0, 0, 1, 3, 4, 0, 0, 1, 0, 5, 0, 0, 5},
-			Rotation: [4]float64{1, 2, 3, 4},
-			Scale:    [3]float64{2, 3, 4},
-			Camera:   Index(1),
-			Mesh:     Index(2),
-			Skin:     Index(3),
+		{"trs", new(Node), args{[]byte(`{"rotation":[1,2,3,4],"scale":[2,3,4],"translation":[5,0,0],"camera":1,"mesh":2,"skin":3}`)}, &Node{
+			Matrix:      [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
+			Rotation:    [4]float64{1, 2, 3, 4},
+			Scale:       [3]float64{2, 3, 4},
+			Translation: [3]float64{5, 0, 0},
+			Camera:      Index(1),
+			Mesh:        Index(2),
+			Skin:        Index(3),
 		}, false},
+		{"matrix-with-trs", new(Node), args{[]byte(`{"matrix":[1,2,2,0,0,1,3,4,0,0,1,0,5,0,0,5],"rotation":[1,2,3,4]}`)}, new(Node), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -368,6 +396,7 @@ func TestMaterial_UnmarshalJSON(t *testing.T) {
 	}{
 		{"default", new(Material), args{[]byte("{}")}, &Material{AlphaCutoff: Float(0.5), AlphaMode: AlphaOpaque}, false},
 		{"nodefault", new(Material), args{[]byte(`{"alphaCutoff": 0.2, "alphaMode": "MASK"}`)}, &Material{AlphaCutoff: Float(0.2), AlphaMode: AlphaMask}, false},
+		{"cutoff-without-mode", new(Material), args{[]byte(`{"alphaCutoff": 0.2}`)}, new(Material), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -393,7 +422,7 @@ func TestNormalTexture_UnmarshalJSON(t *testing.T) {
 		want    *NormalTexture
 		wantErr bool
 	}{
-		{"default", new(NormalTexture), args{[]byte("{}")}, &NormalTexture{Scale: Float(1)}, false},
+		{"default", new(NormalTexture), args{[]byte("{}")}, new(NormalTexture), true},
 		{"empty", new(NormalTexture), args{[]byte(`{"scale": 0, "index": 0}`)}, &NormalTexture{Scale: Float(0), Index: Index(0)}, false},
 		{"nodefault", new(NormalTexture), args{[]byte(`{"scale": 0.5, "index":2}`)}, &NormalTexture{Scale: Float(0.5), Index: Index(2)}, false},
 	}
@@ -421,7 +450,7 @@ func TestOcclusionTexture_UnmarshalJSON(t *testing.T) {
 		want    *OcclusionTexture
 		wantErr bool
 	}{
-		{"default", new(OcclusionTexture), args{[]byte("{}")}, &OcclusionTexture{Strength: Float(1)}, false},
+		{"default", new(OcclusionTexture), args{[]byte("{}")}, new(OcclusionTexture), true},
 		{"empty", new(OcclusionTexture), args{[]byte(`{"strength": 0, "index": 0}`)}, &OcclusionTexture{Strength: Float(0), Index: Index(0)}, false},
 		{"nodefault", new(OcclusionTexture), args{[]byte(`{"strength": 0.5, "index":2}`)}, &OcclusionTexture{Strength: Float(0.5), Index: Index(2)}, false},
 	}
@@ -492,15 +521,24 @@ func TestNode_MarshalJSON(t *testing.T) {
 			Skin:     Index(0),
 			Mesh:     Index(0),
 		}, []byte(`{"camera":0,"skin":0,"mesh":0}`), false},
-		{"nodefault", &Node{
-			Matrix:      [16]float64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		{"matrix", &Node{
+			Matrix: [16]float64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Camera: Index(1),
+			Skin:   Index(1),
+			Mesh:   Index(1),
+		}, []byte(`{"matrix":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"camera":1,"skin":1,"mesh":1}`), false},
+		{"trs", &Node{
 			Rotation:    [4]float64{1, 0, 0, 0},
 			Scale:       [3]float64{1, 0, 0},
 			Translation: [3]float64{1, 0, 0},
 			Camera:      Index(1),
 			Skin:        Index(1),
 			Mesh:        Index(1),
-		}, []byte(`{"matrix":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"rotation":[1,0,0,0],"scale":[1,0,0],"translation":[1,0,0],"camera":1,"skin":1,"mesh":1}`), false},
+		}, []byte(`{"rotation":[1,0,0,0],"scale":[1,0,0],"translation":[1,0,0],"camera":1,"skin":1,"mesh":1}`), false},
+		{"matrix-with-trs", &Node{
+			Matrix:      [16]float64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Translation: [3]float64{1, 0, 0},
+		}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -526,6 +564,7 @@ func TestMaterial_MarshalJSON(t *testing.T) {
 		{"default", &Material{AlphaCutoff: Float(0.5), AlphaMode: AlphaOpaque}, []byte(`{}`), false},
 		{"empty", &Material{AlphaMode: AlphaBlend}, []byte(`{"alphaMode":"BLEND"}`), false},
 		{"nodefault", &Material{AlphaCutoff: Float(1), AlphaMode: AlphaBlend}, []byte(`{"alphaCutoff":1,"alphaMode":"BLEND"}`), false},
+		{"cutoff-without-mode", &Material{AlphaCutoff: Float(1)}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -548,7 +587,7 @@ func TestNormalTexture_MarshalJSON(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"default", &NormalTexture{Scale: Float(1)}, []byte(`{}`), false},
+		{"default", &NormalTexture{Scale: Float(1)}, nil, true},
 		{"empty", &NormalTexture{Index: Index(0)}, []byte(`{"index":0}`), false},
 		{"nodefault", &NormalTexture{Index: Index(1), Scale: Float(0.5)}, []byte(`{"index":1,"scale":0.5}`), false},
 	}
@@ -573,7 +612,7 @@ func TestOcclusionTexture_MarshalJSON(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"default", &OcclusionTexture{Strength: Float(1)}, []byte(`{}`), false},
+		{"default", &OcclusionTexture{Strength: Float(1)}, nil, true},
 		{"empty", &OcclusionTexture{Index: Index(0)}, []byte(`{"index":0}`), false},
 		{"nodefault", &OcclusionTexture{Index: Index(1), Strength: Float(0.5)}, []byte(`{"index":1,"strength":0.5}`), false},
 	}
@@ -624,6 +663,9 @@ func TestCamera_MarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"empty", &Camera{}, nil, true},
+		{"perspective", &Camera{Perspective: &Perspective{Yfov: 2, Znear: 4}}, []byte(`{"type":"perspective","perspective":{"yfov":2,"znear":4}}`), false},
+		{"orthographic", &Camera{Orthographic: &Orthographic{Xmag: 1, Ymag: 2, Zfar: 3, Znear: 4}}, []byte(`{"type":"orthographic","orthographic":{"xmag":1,"ymag":2,"zfar":3,"znear":4}}`), false},
+		{"mismatch", &Camera{Type: "perspective", Orthographic: &Orthographic{Xmag: 1, Ymag: 2, Zfar: 3, Znear: 4}}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -634,6 +676,56 @@ func TestCamera_MarshalJSON(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Camera.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCamera_MarshalJSON_AutoPopulatesType(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Camera
+		want string
+	}{
+		{"perspective", &Camera{Perspective: &Perspective{Yfov: 2, Znear: 4}}, "perspective"},
+		{"orthographic", &Camera{Orthographic: &Orthographic{Xmag: 1, Ymag: 2, Zfar: 3, Znear: 4}}, "orthographic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.c.MarshalJSON(); err != nil {
+				t.Fatalf("Camera.MarshalJSON() error = %v", err)
+			}
+			if tt.c.Type != tt.want {
+				t.Errorf("Camera.Type = %q, want %q", tt.c.Type, tt.want)
+			}
+		})
+	}
+}
+
+func TestCamera_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    *Camera
+		wantErr bool
+	}{
+		{"perspective", []byte(`{"type":"perspective","perspective":{"yfov":2,"znear":4}}`), &Camera{Type: "perspective", Perspective: &Perspective{Yfov: 2, Znear: 4}}, false},
+		{"orthographic", []byte(`{"type":"orthographic","orthographic":{"xmag":1,"ymag":2,"zfar":3,"znear":4}}`), &Camera{Type: "orthographic", Orthographic: &Orthographic{Xmag: 1, Ymag: 2, Zfar: 3, Znear: 4}}, false},
+		{"missing-type", []byte(`{"perspective":{"yfov":2,"znear":4}}`), new(Camera), true},
+		{"missing-projection", []byte(`{"type":"perspective"}`), new(Camera), true},
+		{"unknown-type", []byte(`{"type":"custom"}`), new(Camera), true},
+		{"both-projections", []byte(`{"type":"perspective","perspective":{"yfov":2,"znear":4},"orthographic":{"xmag":1,"ymag":2,"zfar":3,"znear":4}}`), new(Camera), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := new(Camera)
+			err := got.UnmarshalJSON(tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Camera.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Camera.UnmarshalJSON() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/gltf.go
+++ b/gltf.go
@@ -120,7 +120,7 @@ type Buffer struct {
 
 // IsEmbeddedResource returns true if the buffer points to an embedded resource.
 func (b *Buffer) IsEmbeddedResource() bool {
-	return strings.HasPrefix(b.URI, mimetypeApplicationOctet)
+	return b.embeddedResourceMimetype() != ""
 }
 
 // EmbeddedResource defines the buffer as an embedded resource and encodes the URI so it points to the the resource.
@@ -128,13 +128,23 @@ func (b *Buffer) EmbeddedResource() {
 	b.URI = mimetypeApplicationOctet + "," + base64.StdEncoding.EncodeToString(b.Data)
 }
 
+func (b *Buffer) embeddedResourceMimetype() string {
+	for _, mimetype := range [...]string{mimetypeApplicationOctet, mimetypeApplicationGltfBuffer} {
+		if strings.HasPrefix(b.URI, mimetype) {
+			return mimetype
+		}
+	}
+	return ""
+}
+
 // marshalData decode the buffer from the URI. If the buffer is not en embedded resource the returned array will be empty.
 func (b *Buffer) marshalData() ([]byte, error) {
-	if !b.IsEmbeddedResource() {
+	mimetype := b.embeddedResourceMimetype()
+	if mimetype == "" {
 		return nil, nil
 	}
-	startPos := len(mimetypeApplicationOctet) + 1
-	if len(b.URI) < startPos {
+	startPos := len(mimetype) + 1
+	if len(b.URI) < startPos || b.URI[len(mimetype)] != ',' {
 		return nil, errors.New("gltf: Invalid base64 content")
 	}
 	sl, err := base64.StdEncoding.DecodeString(b.URI[startPos:])
@@ -225,6 +235,7 @@ type Camera struct {
 	Extensions   Extensions    `json:"extensions,omitempty"`
 	Extras       any           `json:"extras,omitempty"`
 	Name         string        `json:"name,omitempty"`
+	Type         string        `json:"type"`
 	Orthographic *Orthographic `json:"orthographic,omitempty"`
 	Perspective  *Perspective  `json:"perspective,omitempty"`
 }
@@ -486,16 +497,9 @@ func queryExtension(key string) (func([]byte) (any, error), bool) {
 }
 
 // SizeOfElement returns the size, in bytes, of an element.
-// The element size may not be (component size) * (number of components),
-// as some of the elements are tightly packed in order to ensure
-// that they are aligned to 4-byte boundaries.
+// Matrix elements may include column padding required by the glTF binary layout.
 func SizeOfElement(c ComponentType, t AccessorType) int {
-	// special cases
 	switch {
-	case (t == AccessorVec3 || t == AccessorVec2) && (c == ComponentByte || c == ComponentUbyte):
-		return 4
-	case t == AccessorVec3 && (c == ComponentShort || c == ComponentUshort):
-		return 8
 	case t == AccessorMat2 && (c == ComponentByte || c == ComponentUbyte):
 		return 8
 	case t == AccessorMat3 && (c == ComponentByte || c == ComponentUbyte):

--- a/gltf_test.go
+++ b/gltf_test.go
@@ -36,6 +36,7 @@ func TestBuffer_IsEmbeddedResource(t *testing.T) {
 		want bool
 	}{
 		{"embedded", &Buffer{URI: "data:application/octet-stream;base64,dsjdsaGGUDXGA"}, true},
+		{"embedded-gltf-buffer", &Buffer{URI: "data:application/gltf-buffer;base64,dsjdsaGGUDXGA"}, true},
 		{"external", &Buffer{URI: "https://web.com/a"}, false},
 	}
 	for _, tt := range tests {
@@ -95,6 +96,7 @@ func TestBuffer_marshalData(t *testing.T) {
 		{"external", &Buffer{URI: "http://web.com"}, nil, false},
 		{"empty", &Buffer{URI: "data:application/octet-stream;base64,"}, nil, false},
 		{"test", &Buffer{URI: "data:application/octet-stream;base64,TEST"}, []byte{76, 68, 147}, false},
+		{"gltf-buffer", &Buffer{URI: "data:application/gltf-buffer;base64,TEST"}, []byte{76, 68, 147}, false},
 		{"complex", &Buffer{URI: "data:application/octet-stream;base64,YW55IGNhcm5hbCBwbGVhcw=="}, []byte{97, 110, 121, 32, 99, 97, 114, 110, 97, 108, 32, 112, 108, 101, 97, 115}, false},
 		{"invalid", &Buffer{URI: "data:application/octet-stream;base64"}, nil, true},
 	}
@@ -305,12 +307,12 @@ func TestSizeOfElement(t *testing.T) {
 		args args
 		want int
 	}{
-		{"byte-vec2", args{ComponentByte, AccessorVec2}, 4},
-		{"ubyte-vec2", args{ComponentUbyte, AccessorVec2}, 4},
-		{"byte-vec3", args{ComponentByte, AccessorVec3}, 4},
-		{"ubyte-vec3", args{ComponentUbyte, AccessorVec3}, 4},
-		{"short-vec3", args{ComponentShort, AccessorVec3}, 8},
-		{"ushort-vec3", args{ComponentUshort, AccessorVec3}, 8},
+		{"byte-vec2", args{ComponentByte, AccessorVec2}, 2},
+		{"ubyte-vec2", args{ComponentUbyte, AccessorVec2}, 2},
+		{"byte-vec3", args{ComponentByte, AccessorVec3}, 3},
+		{"ubyte-vec3", args{ComponentUbyte, AccessorVec3}, 3},
+		{"short-vec3", args{ComponentShort, AccessorVec3}, 6},
+		{"ushort-vec3", args{ComponentUshort, AccessorVec3}, 6},
 		{"byte-mat2", args{ComponentByte, AccessorMat2}, 8},
 		{"ubyte-mat2", args{ComponentUbyte, AccessorMat2}, 8},
 		{"byte-mat3", args{ComponentByte, AccessorMat3}, 12},

--- a/modeler/write.go
+++ b/modeler/write.go
@@ -223,6 +223,7 @@ func WriteAccessorsInterleaved(doc *gltf.Document, data ...any) ([]int, error) {
 	var byteOffset int
 	for i, d := range data {
 		c, t, l := binary.Type(d)
+		byteOffset = align4(byteOffset)
 		doc.Accessors = append(doc.Accessors, &gltf.Accessor{
 			BufferView:    gltf.Index(index),
 			ByteOffset:    byteOffset,
@@ -324,12 +325,23 @@ func writeBufferViews(doc *gltf.Document, target gltf.Target, data ...any) (int,
 			return 0, errors.New("gltf: interleaved data shall have the same number of elements in all chunks")
 		}
 		sizeOfElement := gltf.SizeOfElement(c, a)
-		size += l * sizeOfElement
 		if len(data) > 1 {
+			stride = align4(stride)
 			stride += sizeOfElement
-		} else if target == gltf.TargetArrayBuffer && c.ByteSize()*a.Components() != sizeOfElement {
-			stride = sizeOfElement
+		} else {
+			paddedSize := sizeOfElement
+			if target == gltf.TargetArrayBuffer {
+				paddedSize = align4(sizeOfElement)
+			}
+			size += l * paddedSize
+			if paddedSize != sizeOfElement {
+				stride = paddedSize
+			}
 		}
+	}
+	if len(data) > 1 {
+		stride = align4(stride)
+		size = refLength * stride
 	}
 	buffer := lastBuffer(doc)
 	offset := len(buffer.Data)
@@ -337,6 +349,9 @@ func writeBufferViews(doc *gltf.Document, target gltf.Target, data ...any) (int,
 	buffer.Data = append(buffer.Data, make([]byte, size)...)
 	dataOffset := offset
 	for _, d := range data {
+		if len(data) > 1 {
+			dataOffset = offset + align4(dataOffset-offset)
+		}
 		// Cannot return error as the buffer has enough size and the data type is controlled.
 		_ = binary.Write(buffer.Data[dataOffset:], stride, d)
 		c, a, _ := binary.Type(d)
@@ -373,6 +388,10 @@ func getPadding(offset int) int {
 		return 0
 	}
 	return 4 - padAlign
+}
+
+func align4(offset int) int {
+	return offset + getPadding(offset)
 }
 
 func sliceLength(data any) int {


### PR DESCRIPTION
## Summary
- validate required glTF fields and invalid enum values during JSON decode/encode
- infer and persist camera type from projection data while preserving zero-value document encoding
- fix binary element sizing/alignment, GLB buffer bounds, and buffer resource handling

## Tests
- go test ./...