### PR TITLE
Improve extension JSON serialization defaults

### DIFF
--- a/ext/lightspunctual/lightspunctual.go
+++ b/ext/lightspunctual/lightspunctual.go
@@ -48,6 +48,14 @@ const (
 // LightIndex is the id of the light referenced by this node.
 type LightIndex int
 
+// MarshalJSON marshals the light index as a node extension payload.
+func (l LightIndex) MarshalJSON() ([]byte, error) {
+	type lightIndexAlias LightIndex
+	return json.Marshal(struct {
+		Light lightIndexAlias `json:"light"`
+	}{Light: lightIndexAlias(l)})
+}
+
 // Spot defines the spot cone.
 type Spot struct {
 	InnerConeAngle float64  `json:"innerConeAngle,omitempty"`
@@ -73,8 +81,26 @@ func (s *Spot) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+// MarshalJSON marshal the spot with default values omitted.
+func (s *Spot) MarshalJSON() ([]byte, error) {
+	type alias Spot
+	tmp := alias(*s)
+	if tmp.OuterConeAngle != nil && *tmp.OuterConeAngle == math.Pi/4 {
+		tmp.OuterConeAngle = nil
+	}
+	return json.Marshal(tmp)
+}
+
 // Lights defines a list of Lights.
 type Lights []*Light
+
+// MarshalJSON marshals the lights list as a root extension payload.
+func (l Lights) MarshalJSON() ([]byte, error) {
+	type lightsAlias Lights
+	return json.Marshal(struct {
+		Lights lightsAlias `json:"lights"`
+	}{Lights: lightsAlias(l)})
+}
 
 // Light defines a directional, point, or spot light.
 // When a light's type is spot, the spot property on the light is required.
@@ -106,10 +132,26 @@ func (l *Light) ColorOrDefault() [3]float64 {
 // UnmarshalJSON unmarshal the light with the correct default values.
 func (l *Light) UnmarshalJSON(data []byte) error {
 	type alias Light
-	tmp := alias(Light{Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1), Range: gltf.Float(math.Inf(0))})
+	tmp := alias(Light{Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1)})
 	err := json.Unmarshal(data, &tmp)
 	if err == nil {
 		*l = Light(tmp)
 	}
 	return err
+}
+
+// MarshalJSON marshal the light with default values omitted.
+func (l *Light) MarshalJSON() ([]byte, error) {
+	type alias Light
+	tmp := alias(*l)
+	if tmp.Color != nil && *tmp.Color == [3]float64{1, 1, 1} {
+		tmp.Color = nil
+	}
+	if tmp.Intensity != nil && *tmp.Intensity == 1 {
+		tmp.Intensity = nil
+	}
+	if tmp.Range != nil && math.IsInf(*tmp.Range, 1) {
+		tmp.Range = nil
+	}
+	return json.Marshal(tmp)
 }

--- a/ext/lightspunctual/lightspunctual_test.go
+++ b/ext/lightspunctual/lightspunctual_test.go
@@ -1,6 +1,7 @@
 package lightspunctual_test
 
 import (
+	"encoding/json"
 	"math"
 	"reflect"
 	"testing"
@@ -76,7 +77,7 @@ func TestLight_UnmarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"default", new(lightspunctual.Light), args{[]byte("{}")}, &lightspunctual.Light{
-			Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1), Range: gltf.Float(math.Inf(0)),
+			Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1),
 		}, false},
 		{"nodefault", new(lightspunctual.Light), args{[]byte(`{
 			"color": [0.3, 0.7, 1.0],
@@ -134,8 +135,8 @@ func TestUnmarshal(t *testing.T) {
 			  "type": "point"
 			}
 		  ]}`)}, lightspunctual.Lights{
-			{Color: &[3]float64{1, 0.9, 0.7}, Name: "Directional", Intensity: gltf.Float(3.0), Type: "directional", Range: gltf.Float(math.Inf(0))},
-			{Color: &[3]float64{1, 0, 0}, Name: "Point", Intensity: gltf.Float(20.0), Type: "point", Range: gltf.Float(math.Inf(0))},
+			{Color: &[3]float64{1, 0.9, 0.7}, Name: "Directional", Intensity: gltf.Float(3.0), Type: "directional"},
+			{Color: &[3]float64{1, 0, 0}, Name: "Point", Intensity: gltf.Float(20.0), Type: "point"},
 		}, false},
 	}
 	for _, tt := range tests {
@@ -149,5 +150,25 @@ func TestUnmarshal(t *testing.T) {
 				t.Errorf("Unmarshal() = %v", diff)
 			}
 		})
+	}
+}
+
+func TestLightIndex_MarshalJSON(t *testing.T) {
+	got, err := json.Marshal(lightspunctual.LightIndex(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []byte(`{"light":1}`); !reflect.DeepEqual(got, want) {
+		t.Errorf("LightIndex.MarshalJSON() = %s, want %s", got, want)
+	}
+}
+
+func TestLights_MarshalJSON(t *testing.T) {
+	got, err := json.Marshal(lightspunctual.Lights{{Name: "Key", Type: lightspunctual.TypeDirectional, Color: &[3]float64{1, 1, 1}, Intensity: gltf.Float(1)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []byte(`{"lights":[{"type":"directional","name":"Key"}]}`); !reflect.DeepEqual(got, want) {
+		t.Errorf("Lights.MarshalJSON() = %s, want %s", got, want)
 	}
 }

--- a/ext/texturetransform/transform.go
+++ b/ext/texturetransform/transform.go
@@ -10,7 +10,6 @@ import (
 var (
 	// DefaultScale defines a scaling that does not modify the size of the object.
 	DefaultScale = [2]float64{1, 1}
-	emptyScale   = [2]float64{0, 0}
 	emptyOffset  = [2]float64{0, 0}
 )
 
@@ -38,11 +37,11 @@ type TextureTranform struct {
 	TexCoord *int       `json:"texCoord,omitempty"`
 }
 
+// TextureTransform is an alias for TextureTranform with the corrected spelling.
+type TextureTransform = TextureTranform
+
 // ScaleOrDefault returns the node scale if it represents a valid scale factor, else return the default one.
 func (t *TextureTranform) ScaleOrDefault() [2]float64 {
-	if t.Scale == emptyScale {
-		return DefaultScale
-	}
 	return t.Scale
 }
 
@@ -64,8 +63,6 @@ func (t *TextureTranform) MarshalJSON() ([]byte, error) {
 	if err == nil {
 		if t.Scale == DefaultScale {
 			out = removeProperty([]byte(`"scale":[1,1]`), out)
-		} else if t.Scale == emptyScale {
-			out = removeProperty([]byte(`"scale":[0,0]`), out)
 		}
 		if t.Offset == emptyOffset {
 			out = removeProperty([]byte(`"offset":[0,0]`), out)

--- a/ext/texturetransform/transform_test.go
+++ b/ext/texturetransform/transform_test.go
@@ -15,7 +15,7 @@ func TestTextureTranform_ScaleOrDefault(t *testing.T) {
 		want [2]float64
 	}{
 		{"default", &texturetransform.TextureTranform{Scale: texturetransform.DefaultScale}, texturetransform.DefaultScale},
-		{"zeros", &texturetransform.TextureTranform{Scale: [2]float64{0, 0}}, texturetransform.DefaultScale},
+		{"zeros", &texturetransform.TextureTranform{Scale: [2]float64{0, 0}}, [2]float64{0, 0}},
 		{"other", &texturetransform.TextureTranform{Scale: [2]float64{1, 2}}, [2]float64{1, 2}},
 	}
 	for _, tt := range tests {
@@ -64,7 +64,7 @@ func TestTextureTranform_MarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"default", &texturetransform.TextureTranform{Scale: texturetransform.DefaultScale}, []byte(`{}`), false},
-		{"empty", &texturetransform.TextureTranform{}, []byte(`{}`), false},
+		{"empty", &texturetransform.TextureTranform{}, []byte(`{"scale":[0,0]}`), false},
 		{"nodefault", &texturetransform.TextureTranform{Offset: [2]float64{0.1, 0.2}, Rotation: 1.57, Scale: [2]float64{1, -1}, TexCoord: gltf.Index(2)}, []byte(`{"offset":[0.1,0.2],"rotation":1.57,"scale":[1,-1],"texCoord":2}`), false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- add JSON marshaling helpers for KHR_lights_punctual node and root extension payloads
- omit default light and spot values during marshaling
- add corrected TextureTransform spelling alias and preserve explicit zero scale values

## Tests
- go test ./...