### PR TITLE
Fix modeler read validation

### DIFF
--- a/binary/encode.go
+++ b/binary/encode.go
@@ -3,8 +3,10 @@ package binary
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"image/color"
 	"io"
+	"math"
 
 	"github.com/qmuntal/gltf"
 )
@@ -17,14 +19,23 @@ import (
 func Read(b []byte, byteStride int, data any) error {
 	c, t, n := Type(data)
 	size := gltf.SizeOfElement(c, t)
+	if byteStride < 0 {
+		return fmt.Errorf("gltf: byte stride %d not allowed", byteStride)
+	}
 	if byteStride == 0 {
 		byteStride = size
 	}
-	e := int(byteStride)
-	high := int(n) * e
-	if byteStride != size {
-		high -= int(byteStride - size)
+	if byteStride < size {
+		return fmt.Errorf("gltf: byte stride %d smaller than element size %d", byteStride, size)
 	}
+	if n == 0 {
+		return nil
+	}
+	if n > 1 && byteStride > (math.MaxInt-size)/(n-1) {
+		return io.ErrShortBuffer
+	}
+	e := byteStride
+	high := size + (n-1)*byteStride
 	if len(b) < high {
 		return io.ErrShortBuffer
 	}

--- a/binary/encode_test.go
+++ b/binary/encode_test.go
@@ -178,6 +178,24 @@ func TestRead(t *testing.T) {
 	}
 }
 
+func TestReadInvalidByteStride(t *testing.T) {
+	tests := []struct {
+		name       string
+		byteStride int
+		data       any
+	}{
+		{"negative", -1, make([]uint16, 2)},
+		{"smaller-than-element", 1, make([]uint16, 2)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := binary.Read(make([]byte, 4), tt.byteStride, tt.data); err == nil {
+				t.Fatal("Read() expected an error")
+			}
+		})
+	}
+}
+
 func TestWrite(t *testing.T) {
 	type args struct {
 		n    int

--- a/binary/slice.go
+++ b/binary/slice.go
@@ -141,6 +141,9 @@ func castSlice(c gltf.ComponentType, t gltf.AccessorType, count int, v []byte) a
 // If the buffer is an slice which type matches with the expected by the acr then it will
 // be used as backing slice.
 func MakeSliceBuffer(c gltf.ComponentType, t gltf.AccessorType, count int, buffer []byte) (any, error) {
+	if count < 0 {
+		return nil, fmt.Errorf("gltf: accessor count %d not allowed", count)
+	}
 	if err := checkAccessorType(c, t); err != nil {
 		return nil, err
 	}
@@ -160,6 +163,9 @@ func MakeSliceBuffer(c gltf.ComponentType, t gltf.AccessorType, count int, buffe
 // For example, if c is gltf.ComponentFloat and t is gltf.AccessorVec3
 // then MakeSlice(c, t, 5) is equivalent to make([][3]float32, 5).
 func MakeSlice(c gltf.ComponentType, t gltf.AccessorType, count int) (any, error) {
+	if count < 0 {
+		return nil, fmt.Errorf("gltf: accessor count %d not allowed", count)
+	}
 	if err := checkAccessorType(c, t); err != nil {
 		return nil, err
 	}

--- a/binary/slice_test.go
+++ b/binary/slice_test.go
@@ -78,6 +78,12 @@ func TestMakeSlice(t *testing.T) {
 	}
 }
 
+func TestMakeSliceNegativeCount(t *testing.T) {
+	if _, err := binary.MakeSlice(gltf.ComponentUbyte, gltf.AccessorScalar, -1); err == nil {
+		t.Fatal("MakeSlice() expected an error")
+	}
+}
+
 func TestMakeSliceBuffer(t *testing.T) {
 	type args struct {
 		c      gltf.ComponentType
@@ -104,5 +110,11 @@ func TestMakeSliceBuffer(t *testing.T) {
 				t.Errorf("MakeSliceBuffer() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMakeSliceBufferNegativeCount(t *testing.T) {
+	if _, err := binary.MakeSliceBuffer(gltf.ComponentUbyte, gltf.AccessorScalar, -1, nil); err == nil {
+		t.Fatal("MakeSliceBuffer() expected an error")
 	}
 }

--- a/modeler/read.go
+++ b/modeler/read.go
@@ -29,23 +29,40 @@ var uint32Pool = sync.Pool{
 // ReadAccessor is safe to use even with malformed documents.
 // If that happens it will return an error instead of panic.
 func ReadAccessor(doc *gltf.Document, acr *gltf.Accessor, buffer []byte) (any, error) {
+	if acr == nil {
+		return nil, errors.New("gltf: accessor is nil")
+	}
+	if acr.Count < 0 {
+		return nil, errCount("accessor", acr.Count)
+	}
 	data, err := binary.MakeSliceBuffer(acr.ComponentType, acr.Type, acr.Count, buffer)
 	if err != nil {
 		return nil, err
 	}
 	if acr.BufferView != nil {
-		buf, err := readBufferView(doc, *acr.BufferView)
+		bv, buf, err := readBufferView(doc, *acr.BufferView)
 		if err != nil {
 			return nil, err
 		}
-		byteStride := doc.BufferViews[*acr.BufferView].ByteStride
-		err = binary.Read(buf[acr.ByteOffset:], byteStride, data)
+		if err := validateByteStride(bv.ByteStride, acr.ComponentType, acr.Type); err != nil {
+			return nil, err
+		}
+		if err := validateAccessorByteOffset(acr.ByteOffset, len(buf)); err != nil {
+			return nil, err
+		}
+		err = binary.Read(buf[acr.ByteOffset:], bv.ByteStride, data)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if acr.Sparse != nil {
+		if acr.Sparse.Count < 0 {
+			return nil, errCount("sparse", acr.Sparse.Count)
+		}
+		if acr.Sparse.Count > acr.Count {
+			return nil, errors.New("gltf: sparse count overflows accessor count")
+		}
 		bufPtr := uint32Pool.Get().(*[]uint32)
 		defer uint32Pool.Put(bufPtr)
 		indices, err := ReadIndices(doc, &gltf.Accessor{
@@ -56,6 +73,9 @@ func ReadAccessor(doc *gltf.Document, acr *gltf.Accessor, buffer []byte) (any, e
 			ByteOffset:    acr.Sparse.Indices.ByteOffset,
 		}, *bufPtr)
 		if err != nil {
+			return nil, err
+		}
+		if err := validateSparseIndices(indices, acr.Count); err != nil {
 			return nil, err
 		}
 
@@ -81,11 +101,22 @@ func ReadAccessor(doc *gltf.Document, acr *gltf.Accessor, buffer []byte) (any, e
 	return data, nil
 }
 
-func readBufferView(doc *gltf.Document, bufferViewIndex int) ([]byte, error) {
-	if len(doc.BufferViews) <= bufferViewIndex {
-		return nil, errors.New("gltf: bufferview index overflows")
+func readBufferView(doc *gltf.Document, bufferViewIndex int) (*gltf.BufferView, []byte, error) {
+	if doc == nil {
+		return nil, nil, errors.New("gltf: document is nil")
 	}
-	return ReadBufferView(doc, doc.BufferViews[bufferViewIndex])
+	if bufferViewIndex < 0 || len(doc.BufferViews) <= bufferViewIndex {
+		return nil, nil, errors.New("gltf: bufferview index overflows")
+	}
+	bv := doc.BufferViews[bufferViewIndex]
+	if bv == nil {
+		return nil, nil, errors.New("gltf: bufferview is nil")
+	}
+	buf, err := ReadBufferView(doc, bv)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bv, buf, nil
 }
 
 // ReadBufferView returns the slice of bytes associated with the BufferView.
@@ -94,16 +125,69 @@ func readBufferView(doc *gltf.Document, bufferViewIndex int) ([]byte, error) {
 // It is safe to use even with malformed documents.
 // If that happens it will return an error instead of panic.
 func ReadBufferView(doc *gltf.Document, bv *gltf.BufferView) ([]byte, error) {
-	if len(doc.Buffers) <= bv.Buffer {
+	if doc == nil {
+		return nil, errors.New("gltf: document is nil")
+	}
+	if bv == nil {
+		return nil, errors.New("gltf: bufferview is nil")
+	}
+	if bv.Buffer < 0 || len(doc.Buffers) <= bv.Buffer {
 		return nil, errors.New("gltf: buffer index overflows")
 	}
-	buf := doc.Buffers[bv.Buffer].Data
-
-	high := bv.ByteOffset + bv.ByteLength
-	if len(buf) < high {
+	buffer := doc.Buffers[bv.Buffer]
+	if buffer == nil {
+		return nil, errors.New("gltf: buffer is nil")
+	}
+	if buffer.ByteLength < 0 || bv.ByteOffset < 0 || bv.ByteLength < 0 {
+		return nil, errors.New("gltf: negative buffer length or offset")
+	}
+	if bv.ByteOffset > buffer.ByteLength || bv.ByteLength > buffer.ByteLength-bv.ByteOffset {
 		return nil, io.ErrShortBuffer
 	}
-	return buf[bv.ByteOffset:high], nil
+
+	high := bv.ByteOffset + bv.ByteLength
+	if len(buffer.Data) < high {
+		return nil, io.ErrShortBuffer
+	}
+	return buffer.Data[bv.ByteOffset:high], nil
+}
+
+func validateAccessorByteOffset(byteOffset, bufferViewLength int) error {
+	if byteOffset < 0 {
+		return errors.New("gltf: accessor byte offset is negative")
+	}
+	if byteOffset > bufferViewLength {
+		return io.ErrShortBuffer
+	}
+	return nil
+}
+
+func validateByteStride(byteStride int, componentType gltf.ComponentType, accessorType gltf.AccessorType) error {
+	if byteStride == 0 {
+		return nil
+	}
+	if byteStride < 0 {
+		return fmt.Errorf("gltf: byte stride %d not allowed", byteStride)
+	}
+	if byteStride < gltf.SizeOfElement(componentType, accessorType) {
+		return fmt.Errorf("gltf: byte stride %d too small", byteStride)
+	}
+	if byteStride < 4 || byteStride > 252 || byteStride%4 != 0 {
+		return fmt.Errorf("gltf: byte stride %d not allowed", byteStride)
+	}
+	return nil
+}
+
+func validateSparseIndices(indices []uint32, count int) error {
+	for i, index := range indices {
+		if uint64(index) >= uint64(count) {
+			return errors.New("gltf: sparse index overflows accessor count")
+		}
+		if i > 0 && index <= indices[i-1] {
+			return errors.New("gltf: sparse indices must be strictly increasing")
+		}
+	}
+	return nil
 }
 
 var bufPool = sync.Pool{
@@ -216,6 +300,9 @@ func ReadTextureCoord(doc *gltf.Document, acr *gltf.Accessor, buffer [][2]float3
 	if acr.Type != gltf.AccessorVec2 {
 		return nil, errAccessorType(acr.Type)
 	}
+	if err := requireNormalizedInteger(acr); err != nil {
+		return nil, err
+	}
 	bufPtr := bufPool.Get().(*[]byte)
 	defer bufPool.Put(bufPtr)
 	data, err := ReadAccessor(doc, acr, *bufPtr)
@@ -255,6 +342,9 @@ func ReadWeights(doc *gltf.Document, acr *gltf.Accessor, buffer [][4]float32) ([
 	}
 	if acr.Type != gltf.AccessorVec4 {
 		return nil, errAccessorType(acr.Type)
+	}
+	if err := requireNormalizedInteger(acr); err != nil {
+		return nil, err
 	}
 	bufPtr := bufPool.Get().(*[]byte)
 	defer bufPool.Put(bufPtr)
@@ -356,6 +446,9 @@ func ReadColor(doc *gltf.Document, acr *gltf.Accessor, buffer [][4]uint8) ([][4]
 	default:
 		return nil, errAccessorType(acr.Type)
 	}
+	if err := requireNormalizedInteger(acr); err != nil {
+		return nil, err
+	}
 	bufPtr := bufPool.Get().(*[]byte)
 	defer bufPool.Put(bufPtr)
 	data, err := ReadAccessor(doc, acr, *bufPtr)
@@ -424,6 +517,9 @@ func ReadColor64(doc *gltf.Document, acr *gltf.Accessor, buffer [][4]uint16) ([]
 	case gltf.AccessorVec3, gltf.AccessorVec4:
 	default:
 		return nil, errAccessorType(acr.Type)
+	}
+	if err := requireNormalizedInteger(acr); err != nil {
+		return nil, err
 	}
 	bufPtr := bufPool.Get().(*[]byte)
 	defer bufPool.Put(bufPtr)
@@ -497,4 +593,15 @@ func errAccessorType(tp gltf.AccessorType) error {
 
 func errComponentType(tp gltf.ComponentType) error {
 	return fmt.Errorf("gltf: component type %v not allowed", tp)
+}
+
+func errCount(name string, count int) error {
+	return fmt.Errorf("gltf: %s count %d not allowed", name, count)
+}
+
+func requireNormalizedInteger(acr *gltf.Accessor) error {
+	if acr.ComponentType != gltf.ComponentFloat && !acr.Normalized {
+		return errors.New("gltf: integer accessor must be normalized")
+	}
+	return nil
 }

--- a/modeler/read_test.go
+++ b/modeler/read_test.go
@@ -21,10 +21,10 @@ func float32Bytes(values ...float32) []byte {
 func TestReadColor64_ReuseBuffer(t *testing.T) {
 	data := []byte{1, 2, 3, 4, 1, 2, 3, 4}
 	acc1 := &gltf.Accessor{
-		BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
+		BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte, Normalized: true,
 	}
 	acc2 := &gltf.Accessor{
-		BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
+		BufferView: gltf.Index(0), Count: 2, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte, Normalized: true,
 	}
 	doc := &gltf.Document{
 		BufferViews: []*gltf.BufferView{
@@ -77,6 +77,28 @@ func TestReadBufferView(t *testing.T) {
 			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
 		}}, &gltf.BufferView{
 			Buffer: 0, ByteLength: 10, ByteOffset: 6,
+		}}, nil, true},
+		{"nil-doc", args{nil, &gltf.BufferView{}}, nil, true},
+		{"nil-bufferview", args{&gltf.Document{}, nil}, nil, true},
+		{"negative-buffer", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		}}, &gltf.BufferView{
+			Buffer: -1, ByteLength: 3,
+		}}, nil, true},
+		{"negative-offset", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		}}, &gltf.BufferView{
+			Buffer: 0, ByteLength: 3, ByteOffset: -1,
+		}}, nil, true},
+		{"negative-length", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		}}, &gltf.BufferView{
+			Buffer: 0, ByteLength: -1,
+		}}, nil, true},
+		{"declared-buffer-short", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 2, Data: []byte{1, 2, 3, 4}},
+		}}, &gltf.BufferView{
+			Buffer: 0, ByteLength: 3,
 		}}, nil, true},
 	}
 	for _, tt := range tests {
@@ -144,6 +166,42 @@ func TestReadAccessor(t *testing.T) {
 		}}}, &gltf.Accessor{
 			BufferView: gltf.Index(1), ByteOffset: 3, ComponentType: gltf.ComponentUbyte, Type: gltf.AccessorScalar, Count: 3,
 		}}, nil, true},
+		{"negative-view", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		}, BufferViews: []*gltf.BufferView{{
+			Buffer: 0, ByteLength: 6, ByteOffset: 3,
+		}}}, &gltf.Accessor{
+			BufferView: gltf.Index(-1), ComponentType: gltf.ComponentUbyte, Type: gltf.AccessorScalar, Count: 3,
+		}}, nil, true},
+		{"negative-offset", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		}, BufferViews: []*gltf.BufferView{{
+			Buffer: 0, ByteLength: 6, ByteOffset: 3,
+		}}}, &gltf.Accessor{
+			BufferView: gltf.Index(0), ByteOffset: -1, ComponentType: gltf.ComponentUbyte, Type: gltf.AccessorScalar, Count: 3,
+		}}, nil, true},
+		{"offset-overflow", args{&gltf.Document{Buffers: []*gltf.Buffer{
+			{ByteLength: 9, Data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		}, BufferViews: []*gltf.BufferView{{
+			Buffer: 0, ByteLength: 6, ByteOffset: 3,
+		}}}, &gltf.Accessor{
+			BufferView: gltf.Index(0), ByteOffset: 7, ComponentType: gltf.ComponentUbyte, Type: gltf.AccessorScalar, Count: 0,
+		}}, nil, true},
+		{"negative-count", args{&gltf.Document{}, &gltf.Accessor{
+			ComponentType: gltf.ComponentFloat, Type: gltf.AccessorScalar, Count: -1,
+		}}, nil, true},
+		{"invalid-stride", args{&gltf.Document{
+			Buffers:     []*gltf.Buffer{{ByteLength: 24, Data: make([]byte, 24)}},
+			BufferViews: []*gltf.BufferView{{Buffer: 0, ByteLength: 24, ByteStride: 4}},
+		}, &gltf.Accessor{
+			BufferView: gltf.Index(0), ComponentType: gltf.ComponentFloat, Type: gltf.AccessorVec3, Count: 2,
+		}}, nil, true},
+		{"nonconformant-stride", args{&gltf.Document{
+			Buffers:     []*gltf.Buffer{{ByteLength: 3, Data: []byte{1, 0, 2}}},
+			BufferViews: []*gltf.BufferView{{Buffer: 0, ByteLength: 3, ByteStride: 2}},
+		}, &gltf.Accessor{
+			BufferView: gltf.Index(0), ComponentType: gltf.ComponentUbyte, Type: gltf.AccessorScalar, Count: 2,
+		}}, nil, true},
 		{"interleaved", args{&gltf.Document{
 			Buffers: []*gltf.Buffer{{ByteLength: 52, Data: []byte{
 				0, 0, 0, 0,
@@ -194,6 +252,67 @@ func TestReadAccessor(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ReadAccessor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadAccessorSparseMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		acr  *gltf.Accessor
+	}{
+		{"index-overflow", append([]byte{2}, float32Bytes(1)...), &gltf.Accessor{
+			ComponentType: gltf.ComponentFloat,
+			Type:          gltf.AccessorScalar,
+			Count:         2,
+			Sparse: &gltf.Sparse{Count: 1,
+				Indices: gltf.SparseIndices{BufferView: 0, ComponentType: gltf.ComponentUbyte},
+				Values:  gltf.SparseValues{BufferView: 1},
+			},
+		}},
+		{"duplicate-indices", append([]byte{1, 1}, float32Bytes(1, 2)...), &gltf.Accessor{
+			ComponentType: gltf.ComponentFloat,
+			Type:          gltf.AccessorScalar,
+			Count:         3,
+			Sparse: &gltf.Sparse{Count: 2,
+				Indices: gltf.SparseIndices{BufferView: 0, ComponentType: gltf.ComponentUbyte},
+				Values:  gltf.SparseValues{BufferView: 1},
+			},
+		}},
+		{"out-of-order-indices", append([]byte{2, 1}, float32Bytes(1, 2)...), &gltf.Accessor{
+			ComponentType: gltf.ComponentFloat,
+			Type:          gltf.AccessorScalar,
+			Count:         3,
+			Sparse: &gltf.Sparse{Count: 2,
+				Indices: gltf.SparseIndices{BufferView: 0, ComponentType: gltf.ComponentUbyte},
+				Values:  gltf.SparseValues{BufferView: 1},
+			},
+		}},
+		{"count-overflow", nil, &gltf.Accessor{
+			ComponentType: gltf.ComponentFloat,
+			Type:          gltf.AccessorScalar,
+			Count:         1,
+			Sparse: &gltf.Sparse{Count: 2,
+				Indices: gltf.SparseIndices{BufferView: 0, ComponentType: gltf.ComponentUbyte},
+				Values:  gltf.SparseValues{BufferView: 1},
+			},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &gltf.Document{}
+			if tt.data != nil {
+				doc.Buffers = []*gltf.Buffer{{Data: tt.data, ByteLength: len(tt.data)}}
+				doc.BufferViews = []*gltf.BufferView{
+					{Buffer: 0, ByteLength: tt.acr.Sparse.Count},
+					{Buffer: 0, ByteOffset: tt.acr.Sparse.Count, ByteLength: len(tt.data) - tt.acr.Sparse.Count},
+				}
+			}
+			if _, err := modeler.ReadAccessor(doc, tt.acr, nil); err == nil {
+				t.Fatal("ReadAccessor() expected an error")
 			}
 		})
 	}
@@ -400,10 +519,10 @@ func TestReadTextureCoord(t *testing.T) {
 		wantErr bool
 	}{
 		{"uint8", args{[]byte{255, 0, 0, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec2, ComponentType: gltf.ComponentUbyte,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec2, ComponentType: gltf.ComponentUbyte, Normalized: true,
 		}, nil}, [][2]float32{{1, 0}}, false},
 		{"uint16", args{[]byte{255, 255, 0, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec2, ComponentType: gltf.ComponentUshort,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec2, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][2]float32{{1, 0}}, false},
 		{"float32", args{[]byte{0, 0, 128, 63, 0, 0, 0, 64}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec2, ComponentType: gltf.ComponentFloat,
@@ -416,6 +535,9 @@ func TestReadTextureCoord(t *testing.T) {
 		}, nil}, nil, true},
 		{"incorrect-componenttype", args{[]byte{}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Type: gltf.AccessorVec2, ComponentType: gltf.ComponentByte,
+		}, nil}, nil, true},
+		{"integer-not-normalized", args{[]byte{255, 0}, &gltf.Accessor{
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec2, ComponentType: gltf.ComponentUbyte,
 		}, nil}, nil, true},
 	}
 	for _, tt := range tests {
@@ -453,10 +575,10 @@ func TestReadWeights(t *testing.T) {
 		wantErr bool
 	}{
 		{"uint8", args{[]byte{255, 0, 255, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte, Normalized: true,
 		}, nil}, [][4]float32{{1, 0, 1, 0}}, false},
 		{"uint16", args{[]byte{0, 0, 255, 255, 0, 0, 255, 255}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]float32{{0, 1, 0, 1}}, false},
 		{"float32", args{[]byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentFloat,
@@ -469,6 +591,9 @@ func TestReadWeights(t *testing.T) {
 		}, nil}, nil, true},
 		{"incorrect-componenttype", args{[]byte{}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Type: gltf.AccessorVec4, ComponentType: gltf.ComponentByte,
+		}, nil}, nil, true},
+		{"integer-not-normalized", args{[]byte{255, 0, 255, 0}, &gltf.Accessor{
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
 		}, nil}, nil, true},
 	}
 	for _, tt := range tests {
@@ -660,11 +785,11 @@ func TestReadColor(t *testing.T) {
 		wantErr bool
 	}{
 		{"[4]uint8", args{[]byte{1, 2, 3, 4}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte, Normalized: true,
 		}, nil}, [][4]uint8{{1, 2, 3, 4}}, false},
 		{"[4]uint16", args{[]byte{0, 0, 115, 33, 200, 0, 255, 255}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort,
-		}, nil}, [][4]uint8{{0, 115, 200, 255}}, false},
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
+		}, nil}, [][4]uint8{{0, 33, 1, 255}}, false},
 		{"[4]uint16-normalized", args{[]byte{0, 1, 115, 33, 200, 0, 255, 255}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]uint8{{1, 33, 1, 255}}, false},
@@ -675,11 +800,11 @@ func TestReadColor(t *testing.T) {
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentFloat,
 		}, nil}, [][4]uint8{{0, 128, 255, 255}}, false},
 		{"[3]uint8", args{[]byte{1, 2, 3, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUbyte,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUbyte, Normalized: true,
 		}, nil}, [][4]uint8{{1, 2, 3, 255}}, false},
 		{"[3]uint16", args{[]byte{0, 0, 255, 0, 255, 0, 0, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort,
-		}, nil}, [][4]uint8{{0, 255, 255, 255}}, false},
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort, Normalized: true,
+		}, nil}, [][4]uint8{{0, 1, 1, 255}}, false},
 		{"[3]uint16-normalized", args{[]byte{0, 1, 255, 0, 255, 0, 0, 0}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]uint8{{1, 1, 1, 255}}, false},
@@ -691,6 +816,9 @@ func TestReadColor(t *testing.T) {
 		}, nil}, nil, true},
 		{"incorrect-componenttype", args{[]byte{}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Type: gltf.AccessorVec4, ComponentType: gltf.ComponentByte,
+		}, nil}, nil, true},
+		{"integer-not-normalized", args{[]byte{1, 2, 3, 4}, &gltf.Accessor{
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
 		}, nil}, nil, true},
 	}
 	for _, tt := range tests {
@@ -728,10 +856,10 @@ func TestReadColor64(t *testing.T) {
 		wantErr bool
 	}{
 		{"[4]uint8", args{[]byte{0, 115, 200, 255}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte, Normalized: true,
 		}, nil}, [][4]uint16{{0, 29555, 51400, 65535}}, false},
 		{"[4]uint16", args{[]byte{0, 0, 255, 255, 0, 0, 255, 255}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]uint16{{0, 65535, 0, 65535}}, false},
 		{"[4]uint16-normalized", args{[]byte{37, 3, 180, 50, 255, 255, 255, 255}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUshort, Normalized: true,
@@ -740,10 +868,10 @@ func TestReadColor64(t *testing.T) {
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentFloat,
 		}, nil}, [][4]uint16{{0, 32768, 65535, 65535}}, false},
 		{"[3]uint8", args{[]byte{0, 100, 200, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUbyte,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUbyte, Normalized: true,
 		}, nil}, [][4]uint16{{0, 25700, 51400, 65535}}, false},
 		{"[3]uint16", args{[]byte{0, 0, 255, 0, 255, 0, 0, 0}, &gltf.Accessor{
-			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort,
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentUshort, Normalized: true,
 		}, nil}, [][4]uint16{{0, 255, 255, 65535}}, false},
 		{"[3]float32", args{float32Bytes(805.0/65535.0, 12980.0/65535.0, 1), &gltf.Accessor{
 			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec3, ComponentType: gltf.ComponentFloat,
@@ -753,6 +881,9 @@ func TestReadColor64(t *testing.T) {
 		}, nil}, nil, true},
 		{"incorrect-componenttype", args{[]byte{}, &gltf.Accessor{
 			BufferView: gltf.Index(0), Type: gltf.AccessorVec4, ComponentType: gltf.ComponentByte,
+		}, nil}, nil, true},
+		{"integer-not-normalized", args{[]byte{0, 115, 200, 255}, &gltf.Accessor{
+			BufferView: gltf.Index(0), Count: 1, Type: gltf.AccessorVec4, ComponentType: gltf.ComponentUbyte,
 		}, nil}, nil, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Summary:
- Harden modeler accessor and buffer view reads against malformed documents.
- Validate sparse indices, byte strides, declared buffer lengths, and normalized integer semantics.
- Add regression coverage for malformed reader inputs and binary slice/stride guards.

Tests:
- go test -count=1 ./...